### PR TITLE
Configure Travis jobs to not cache newly installed jars.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
         - CMD="./gradlew build"
 script: eval $CMD
 
+before_cache:
+  - rm -rfv ~/.m2/repository/org/eclipse/collections/
+
 cache:
   directories:
   - ~/.m2


### PR DESCRIPTION
Speeds up the build by about 30 seconds.