### PR TITLE
Fix formatting of hints and add missing Bag, Multimap.

### DIFF
--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise1Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise1Test.java
@@ -22,6 +22,7 @@ public class Exercise1Test extends PetDomainForKata
     public void getFirstNamesOfAllPeople()
     {
         MutableList<Person> people = this.people;
+        // Replace null, with a transformation method on MutableList.
         MutableList<String> firstNames = null;
         MutableList<String> expectedFirstNames = Lists.mutable.with("Mary", "Bob", "Ted", "Jake", "Barry", "Terry", "Harry", "John");
         Assert.assertEquals(expectedFirstNames, firstNames);
@@ -32,7 +33,8 @@ public class Exercise1Test extends PetDomainForKata
     {
         Person person = this.getPersonNamed("Mary Smith");
         MutableList<Pet> pets = person.getPets();
-        MutableList<String> names = null; //Replace null, with a transformation method on MutableList.
+        // Replace null, with a transformation method on MutableList.
+        MutableList<String> names = null;
         Assert.assertEquals("Tabby", names.makeString());
     }
 

--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise2Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise2Test.java
@@ -25,7 +25,8 @@ public class Exercise2Test extends PetDomainForKata
     @Test
     public void doAnyPeopleHaveCats()
     {
-        Predicate<Person> predicate = null; //replace null with a predicate which checks for PetType.CAT
+    	// Replace null with a predicate which checks for PetType.CAT
+        Predicate<Person> predicate = null;
         Assert.assertTrue(this.people.anySatisfy(predicate));
     }
 
@@ -33,7 +34,8 @@ public class Exercise2Test extends PetDomainForKata
     public void doAllPeopleHavePets()
     {
         Predicate<Person> predicate = person -> person.isPetPerson();
-        boolean result = true; //replace with something that checks if all people have pets
+        // Replace with something that checks if all people have pets
+        boolean result = true;
         Assert.assertFalse(result);
     }
 
@@ -55,7 +57,8 @@ public class Exercise2Test extends PetDomainForKata
     @Test
     public void getPeopleWithPets()
     {
-        MutableList<Person> petPeople = this.people; //replace with only the pet owners
+    	// Replace with only the pet owners
+        MutableList<Person> petPeople = this.people;
         Verify.assertSize(7, petPeople);
     }
 
@@ -84,7 +87,7 @@ public class Exercise2Test extends PetDomainForKata
         boolean peopleHaveCatsLambda = this.people.anySatisfy(person -> person.hasPet(PetType.CAT));
         Assert.assertTrue(peopleHaveCatsLambda);
 
-        //use method reference, NOT lambdas, to solve the problem below
+        // Use method reference, NOT lambdas, to solve the problem below
         boolean peopleHaveCatsMethodRef = false;
         Assert.assertTrue(peopleHaveCatsMethodRef);
     }
@@ -95,7 +98,7 @@ public class Exercise2Test extends PetDomainForKata
         boolean peopleHaveCatsLambda = this.people.allSatisfy(person -> person.hasPet(PetType.CAT));
         Assert.assertFalse(peopleHaveCatsLambda);
 
-        //use method reference, NOT lambdas, to solve the problem below
+        // Use method reference, NOT lambdas, to solve the problem below
         boolean peopleHaveCatsMethodRef = true;
         Assert.assertFalse(peopleHaveCatsMethodRef);
     }
@@ -103,7 +106,7 @@ public class Exercise2Test extends PetDomainForKata
     @Test
     public void getPeopleWithCatsRefator()
     {
-        //use method reference, NOT lambdas, to solve the problem below
+        // Use method reference, NOT lambdas, to solve the problem below
         MutableList<Person> peopleWithCatsMethodRef = null;
         Verify.assertSize(2, peopleWithCatsMethodRef);
     }
@@ -111,7 +114,7 @@ public class Exercise2Test extends PetDomainForKata
     @Test
     public void getPeopleWithoutCatsRefactor()
     {
-        //use method reference, NOT lambdas, to solve the problem below
+        // Use method reference, NOT lambdas, to solve the problem below
         MutableList<Person> peopleWithoutCatsMethodRef = null;
         Verify.assertSize(6, peopleWithoutCatsMethodRef);
     }

--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise3Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise3Test.java
@@ -10,8 +10,10 @@
 
 package org.eclipse.collections.petkata;
 
+import org.eclipse.collections.api.bag.Bag;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.multimap.Multimap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.factory.Maps;
@@ -27,6 +29,7 @@ public class Exercise3Test extends PetDomainForKata
     {
         MutableList<PetType> petTypes = this.people.flatCollect(Person::getPets).collect(Pet::getType);
         // Try to replace MutableMap<PetType, Integer> with a Bag<PetType>
+        Bag<PetType> counts = null;
         MutableMap<PetType, Integer> petTypeCounts = Maps.mutable.empty();
         for (PetType petType : petTypes)
         {
@@ -44,16 +47,18 @@ public class Exercise3Test extends PetDomainForKata
         Assert.assertEquals(Integer.valueOf(1), petTypeCounts.get(PetType.SNAKE));
         Assert.assertEquals(Integer.valueOf(1), petTypeCounts.get(PetType.TURTLE));
         Assert.assertEquals(Integer.valueOf(1), petTypeCounts.get(PetType.BIRD));
-
-        Assert.fail("Optimize this test by using a Bag with variable name 'counts'");
-        /*
+        
         Assert.assertEquals(2, counts.occurrencesOf(PetType.CAT));
         Assert.assertEquals(2, counts.occurrencesOf(PetType.DOG));
         Assert.assertEquals(2, counts.occurrencesOf(PetType.HAMSTER));
         Assert.assertEquals(1, counts.occurrencesOf(PetType.SNAKE));
         Assert.assertEquals(1, counts.occurrencesOf(PetType.TURTLE));
         Assert.assertEquals(1, counts.occurrencesOf(PetType.BIRD));
-        */
+
+        // Don't forget to comment this out or delete it when you are done
+        Assert.fail("Optimize this test by using a Bag with variable name 'counts'");
+        
+        
     }
 
     @Test
@@ -61,7 +66,9 @@ public class Exercise3Test extends PetDomainForKata
     {
         // Try to replace MutableMap<String, MutableList<Person> with a Multimap
         // Hint: use the groupBy method
-        MutableMap<String, MutableList<Person>> lastNamesToPeople = Maps.mutable.empty();
+    	Multimap<String, Person> byLastNameMultimap = null;
+        
+    	MutableMap<String, MutableList<Person>> lastNamesToPeople = Maps.mutable.empty();
         for (Person person : this.people)
         {
             String lastName = person.getLastName();
@@ -74,10 +81,11 @@ public class Exercise3Test extends PetDomainForKata
             peopleWithLastName.add(person);
         }
         Verify.assertIterableSize(3, lastNamesToPeople.get("Smith"));
-        Assert.fail("Optimize this test by using a Multimap");
-
-        //replace assertion with the below
-        //Verify.assertIterableSize(3, byLastNameMultimap.get("Smith"));
+        
+        Verify.assertIterableSize(3, byLastNameMultimap.get("Smith"));
+        
+        // Don't forget to comment this out or delete it when you are done
+        Assert.fail("Optimize this test by using a Multimap with variable name 'byLastNameMultimap'");
     }
 
     @Test

--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
@@ -67,13 +67,13 @@ public class Exercise4Test extends PetDomainForKata
     @Test
     public void streamsToECRefactor1()
     {
-        //find Bob Smith
+        // Find Bob Smith
         Person person =
                 this.people.stream()
                         .filter(each -> each.named("Bob Smith"))
                         .findFirst().get();
 
-        //get Bob Smith's pets' names
+        // Get Bob Smith's pets' names
         String names =
                 person.getPets().stream()
                         .map(Pet::getName)

--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise5Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise5Test.java
@@ -85,7 +85,7 @@ public class Exercise5Test extends PetDomainForKata
         }
 
         Assert.assertEquals(Sets.mutable.with(1, 2, 3, 4), petAges);
-        //extra bonus - convert to a primitive collection
+        // Extra bonus - convert to a primitive collection
         Assert.assertEquals(IntSets.mutable.with(1, 2, 3, 4), petAges);
 
         Assert.fail("Refactor to Eclipse Collections");


### PR DESCRIPTION
The formatting of hints is fixed for indentation and capitalization.

In Exercise3: 
1) The failure message which asks to create a `Bag` named _count_ might be missed, to avoid that added a _null_ `Bag`. Uncommented the assertions so that they fail. 
2) The failure message did not mention to create a `Multimap` named _byLastNameMultimap_, added the name in failure message and a _null_ `Multimap`. Uncommented the assertions so that they fail.