### PR TITLE
Fix formatting of hints and remove unnecessary imports.

### DIFF
--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise2Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise2Test.java
@@ -25,7 +25,8 @@ public class Exercise2Test extends PetDomainForKata
     @Test
     public void doAnyPeopleHaveCats()
     {
-        Predicate<Person> predicate = person -> person.hasPet(PetType.CAT); //replace null with a predicate which checks for PetType.CAT
+    	// Replace null with a predicate which checks for PetType.CAT
+        Predicate<Person> predicate = person -> person.hasPet(PetType.CAT);
         Assert.assertTrue(this.people.anySatisfy(predicate));
     }
 
@@ -33,7 +34,8 @@ public class Exercise2Test extends PetDomainForKata
     public void doAllPeopleHavePets()
     {
         Predicate<Person> predicate = person -> person.isPetPerson();
-        boolean result = this.people.allSatisfy(predicate); //replace with something that checks if all people have pets
+        // Replace with something that checks if all people have pets
+        boolean result = this.people.allSatisfy(predicate);
         Assert.assertFalse(result);
     }
 
@@ -84,7 +86,7 @@ public class Exercise2Test extends PetDomainForKata
         boolean peopleHaveCatsLambda = this.people.anySatisfy(person -> person.hasPet(PetType.CAT));
         Assert.assertTrue(peopleHaveCatsLambda);
 
-        //use method reference, NOT lambdas, to solve the problem below
+        // Use method reference, NOT lambdas, to solve the problem below
         boolean peopleHaveCatsMethodRef = this.people.anySatisfyWith(Person::hasPet, PetType.CAT);
         Assert.assertTrue(peopleHaveCatsMethodRef);
     }
@@ -95,7 +97,7 @@ public class Exercise2Test extends PetDomainForKata
         boolean peopleHaveCatsLambda = this.people.allSatisfy(person -> person.hasPet(PetType.CAT));
         Assert.assertFalse(peopleHaveCatsLambda);
 
-        //use method reference, NOT lambdas, to solve the problem below
+        // Use method reference, NOT lambdas, to solve the problem below
         boolean peopleHaveCatsMethodRef = this.people.allSatisfyWith(Person::hasPet, PetType.CAT);
         Assert.assertFalse(peopleHaveCatsMethodRef);
     }
@@ -103,7 +105,7 @@ public class Exercise2Test extends PetDomainForKata
     @Test
     public void getPeopleWithCatsRefator()
     {
-        //use method reference, NOT lambdas, to solve the problem below
+        // Use method reference, NOT lambdas, to solve the problem below
         MutableList<Person> peopleWithCatsMethodRef = this.people.selectWith(Person::hasPet, PetType.CAT);
         Verify.assertSize(2, peopleWithCatsMethodRef);
     }
@@ -111,7 +113,7 @@ public class Exercise2Test extends PetDomainForKata
     @Test
     public void getPeopleWithoutCatsRefactor()
     {
-        //use method reference, NOT lambdas, to solve the problem below
+        // Use method reference, NOT lambdas, to solve the problem below
         MutableList<Person> peopleWithoutCatsMethodRef = this.people.rejectWith(Person::hasPet, PetType.CAT);
         Verify.assertSize(6, peopleWithoutCatsMethodRef);
     }

--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise3Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise3Test.java
@@ -12,13 +12,8 @@ package org.eclipse.collections.petkata;
 
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.list.MutableListMultimap;
 import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
-import org.eclipse.collections.api.set.MutableSet;
-import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Maps;
-import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;

--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
@@ -10,25 +10,19 @@
 
 package org.eclipse.collections.petkata;
 
+import java.util.IntSummaryStatistics;
+
 import org.eclipse.collections.api.bag.MutableBag;
 import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.list.primitive.IntList;
-import org.eclipse.collections.api.multimap.list.MutableListMultimap;
-import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.set.primitive.IntSet;
 import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
-import org.eclipse.collections.impl.factory.Sets;
-import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import org.eclipse.collections.impl.test.Verify;
-import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class Exercise4Test extends PetDomainForKata
 {
@@ -58,10 +52,10 @@ public class Exercise4Test extends PetDomainForKata
     @Test
     public void streamsToECRefactor1()
     {
-        //find Bob Smith
+        // Find Bob Smith
         Person person = this.people.detect(each -> each.named("Bob Smith"));
 
-        //get Bob Smith's pets' names
+        // Get Bob Smith's pets' names
         String names = person.getPets().collect(Pet::getName).makeString(" & ");
 
         Assert.assertEquals("Dolly & Spot", names);

--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise5Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise5Test.java
@@ -14,7 +14,6 @@ import org.eclipse.collections.api.list.MutableList;
 import org.eclipse.collections.api.partition.list.PartitionMutableList;
 import org.eclipse.collections.api.set.primitive.MutableIntSet;
 import org.eclipse.collections.impl.factory.Lists;
-import org.eclipse.collections.impl.factory.Sets;
 import org.eclipse.collections.impl.factory.primitive.IntSets;
 import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
@@ -72,7 +71,7 @@ public class Exercise5Test extends PetDomainForKata
 
         MutableIntSet petAges = people.flatCollect(Person::getPets).collectInt(Pet::getAge).toSet();
 
-        //extra bonus - convert to a primitive collection
+        // Extra bonus - convert to a primitive collection
         Assert.assertEquals(IntSets.mutable.with(1, 2, 3, 4), petAges);
     }
 }


### PR DESCRIPTION
1) Fix formatting of hints in Exercise2.
2) Remove unnecessary imports from Exercise3, Exercise4, Exercise5.