### PR TITLE
Finish upgrade to 7.1.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,9 +24,9 @@ subprojects {
   }
 
   dependencies {
-    compile 'org.eclipse.collections:eclipse-collections-api:7.0.0'
-    compile 'org.eclipse.collections:eclipse-collections:7.0.0'
-    testCompile 'org.eclipse.collections:eclipse-collections-testutils:7.0.0'
+    compile 'org.eclipse.collections:eclipse-collections-api:7.1.0'
+    compile 'org.eclipse.collections:eclipse-collections:7.1.0'
+    testCompile 'org.eclipse.collections:eclipse-collections-testutils:7.1.0'
     compile 'junit:junit:4.12'
   }
 }

--- a/company-kata/company-kata.iml
+++ b/company-kata/company-kata.iml
@@ -14,9 +14,9 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections-api:7.0.0" level="project" />
-    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections:7.0.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.eclipse.collections:eclipse-collections-testutils:7.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections-api:7.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections:7.1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.eclipse.collections:eclipse-collections-testutils:7.1.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: commons-codec:commons-codec:1.10" level="project" />
     <orderEntry type="library" name="Gradle: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />

--- a/pet-kata/pet-kata.iml
+++ b/pet-kata/pet-kata.iml
@@ -14,9 +14,9 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections-api:7.0.0" level="project" />
-    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections:7.0.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Gradle: org.eclipse.collections:eclipse-collections-testutils:7.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections-api:7.1.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections:7.1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.eclipse.collections:eclipse-collections-testutils:7.1.0" level="project" />
     <orderEntry type="library" scope="TEST" name="Gradle: commons-codec:commons-codec:1.10" level="project" />
     <orderEntry type="library" name="Gradle: junit:junit:4.12" level="project" />
     <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />


### PR DESCRIPTION
This uses 7.1.0 in the eclipse projects created via gradlew eclipse.

Signed-off-by: William Kilian <william.kilian@targetstream.com>