### PR TITLE
Ignore Eclipse related resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ eclipse-collections-kata-parent.userlibraries
 eclipse-collections-kata.userlibraries
 gradle.prefs
 .idea/workspace.xml
+bin
+.settings
+.classpath
+.project


### PR DESCRIPTION
After running gradlew eclipse you would get some unstaged changes for the following folders / files
This PR adds them to .gitignore