### PR TITLE
Fix typo in the word extention

### DIFF
--- a/docs/pet-kata/slides.md
+++ b/docs/pet-kata/slides.md
@@ -205,7 +205,7 @@ TestUtils
  * Eclipse Collections distribution includes `eclipse-collections-testutils.jar`.
    * Includes helpful utility for writing unit tests.
    * Collection specific.
-   * Implemented as an extention of JUnit.
+   * Implemented as an extension of JUnit.
    * Better error messages.
    * Most important class is called `Verify`.
 


### PR DESCRIPTION
The word extension has a spelling error in the following section:
- Exercise 2 -> TestUtils

> Implemented as an **extention** of JUnit.

As per http://www.yourdictionary.com/extention

This change fixes the typo.