### PR TITLE
WIP: Create pet-kata-solutions module

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,35 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CompilerConfiguration">
-    <resourceExtensions />
-    <wildcardResourcePatterns>
-      <entry name="!?*.java" />
-      <entry name="!?*.form" />
-      <entry name="!?*.class" />
-      <entry name="!?*.groovy" />
-      <entry name="!?*.scala" />
-      <entry name="!?*.flex" />
-      <entry name="!?*.kt" />
-      <entry name="!?*.clj" />
-      <entry name="!?*.aj" />
-    </wildcardResourcePatterns>
-    <annotationProcessing>
-      <profile default="true" name="Default" enabled="false">
-        <processorPath useClasspath="true" />
-      </profile>
-      <profile default="false" name="Maven default annotation processors profile" enabled="true">
-        <sourceOutputDir name="target/generated-sources/annotations" />
-        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
-        <outputRelativeToContentRoot value="true" />
-        <processorPath useClasspath="true" />
-        <module name="company-kata" />
-        <module name="pet-kata" />
-      </profile>
-    </annotationProcessing>
-    <bytecodeTargetLevel>
-      <module name="company-kata" target="1.8" />
-      <module name="eclipse-collections-kata" target="1.8" />
-      <module name="pet-kata" target="1.8" />
-    </bytecodeTargetLevel>
-  </component>
+    <component name="CompilerConfiguration">
+        <resourceExtensions />
+        <wildcardResourcePatterns>
+            <entry name="!?*.java" />
+            <entry name="!?*.form" />
+            <entry name="!?*.class" />
+            <entry name="!?*.groovy" />
+            <entry name="!?*.scala" />
+            <entry name="!?*.flex" />
+            <entry name="!?*.kt" />
+            <entry name="!?*.clj" />
+            <entry name="!?*.aj" />
+        </wildcardResourcePatterns>
+        <annotationProcessing>
+            <profile default="true" name="Default" enabled="false">
+                <processorPath useClasspath="true" />
+            </profile>
+            <profile default="false" name="Maven default annotation processors profile" enabled="true">
+                <sourceOutputDir name="target/generated-sources/annotations" />
+                <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+                <outputRelativeToContentRoot value="true" />
+                <processorPath useClasspath="true" />
+                <module name="company-kata" />
+                <module name="pet-kata" />
+                <module name="pet-kata-solutions" />
+            </profile>
+        </annotationProcessing>
+        <bytecodeTargetLevel>
+            <module name="company-kata" target="1.8" />
+            <module name="eclipse-collections-kata" target="1.8" />
+            <module name="pet-kata" target="1.8" />
+            <module name="pet-kata-solutions" target="1.8" />
+        </bytecodeTargetLevel>
+    </component>
 </project>

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -4,6 +4,7 @@
     <file url="file://$PROJECT_DIR$" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/company-kata" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/pet-kata" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/pet-kata-solutions" charset="UTF-8" />
     <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -5,6 +5,7 @@
       <module fileurl="file://$PROJECT_DIR$/company-kata/company-kata.iml" filepath="$PROJECT_DIR$/company-kata/company-kata.iml" />
       <module fileurl="file://$PROJECT_DIR$/eclipse-collections-kata.iml" filepath="$PROJECT_DIR$/eclipse-collections-kata.iml" />
       <module fileurl="file://$PROJECT_DIR$/pet-kata/pet-kata.iml" filepath="$PROJECT_DIR$/pet-kata/pet-kata.iml" />
+      <module fileurl="file://$PROJECT_DIR$/pet-kata-solutions/pet-kata-solutions.iml" filepath="$PROJECT_DIR$/pet-kata-solutions/pet-kata-solutions.iml" />
     </modules>
   </component>
 </project>

--- a/pet-kata-solutions/pet-kata-solutions.iml
+++ b/pet-kata-solutions/pet-kata-solutions.iml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id=":pet-kata-solutions" org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections-api:7.0.0" level="project" />
+    <orderEntry type="library" name="Gradle: org.eclipse.collections:eclipse-collections:7.0.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: org.eclipse.collections:eclipse-collections-testutils:7.0.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Gradle: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" name="Gradle: junit:junit:4.12" level="project" />
+    <orderEntry type="library" name="Gradle: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.collections:eclipse-collections-api:7.0.0" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.collections:eclipse-collections:7.0.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.eclipse.collections:eclipse-collections-testutils:7.0.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" name="Maven: junit:junit:4.12" level="project" />
+    <orderEntry type="library" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+  </component>
+</module>

--- a/pet-kata-solutions/pom.xml
+++ b/pet-kata-solutions/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2018 Goldman Sachs.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ and Eclipse Distribution License v. 1.0 which accompany this distribution.
+  ~ The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~ and the Eclipse Distribution License is available at
+  ~ http://www.eclipse.org/org/documents/edl-v10.php.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>eclipse-collections-kata-parent</artifactId>
+        <groupId>org.eclipse.collections.kata</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pet-kata-solutions</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-testutils</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/Person.java
+++ b/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/Person.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.block.factory.Predicates2;
+import org.eclipse.collections.impl.list.mutable.FastList;
+
+public class Person
+{
+    private final String firstName;
+    private final String lastName;
+    private final MutableList<Pet> pets = FastList.newList();
+
+    public Person(String firstName, String lastName)
+    {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public String getFirstName()
+    {
+        return this.firstName;
+    }
+
+    public String getLastName()
+    {
+        return this.lastName;
+    }
+
+    public boolean named(String name)
+    {
+        return name.equals(this.firstName + ' ' + this.lastName);
+    }
+
+    public boolean hasPet(PetType petType)
+    {
+        return this.pets.anySatisfyWith(Predicates2.attributeEqual(Pet::getType), petType);
+    }
+
+    public MutableList<Pet> getPets()
+    {
+        return this.pets;
+    }
+
+    public MutableBag<PetType> getPetTypes()
+    {
+        return this.pets.collect(Pet::getType, HashBag.newBag());
+    }
+
+    public Person addPet(PetType petType, String name, int age)
+    {
+        this.pets.add(new Pet(petType, name, age));
+        return this;
+    }
+
+    public boolean isPetPerson()
+    {
+        return this.getNumberOfPets() >= 1;
+    }
+
+    public int getNumberOfPets()
+    {
+        return this.pets.size();
+    }
+}

--- a/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/Pet.java
+++ b/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/Pet.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+public class Pet
+{
+    private final PetType type;
+    private final String name;
+    private final int age;
+
+    public Pet(PetType type, String name, int age)
+    {
+        this.type = type;
+        this.name = name;
+        this.age = age;
+    }
+
+    public PetType getType()
+    {
+        return this.type;
+    }
+
+    public String getName()
+    {
+        return this.name;
+    }
+
+    public int getAge()
+    {
+        return this.age;
+    }
+}

--- a/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/PetType.java
+++ b/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/PetType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 Goldman Sachs.
+ * Copyright (c) 2018 Goldman Sachs.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -8,4 +8,9 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  */
 
-include 'company-kata', 'pet-kata', 'pet-kata-solutions'
+package org.eclipse.collections.petkata;
+
+public enum PetType
+{
+    CAT, DOG, HAMSTER, TURTLE, BIRD, SNAKE
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise1Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise1Test.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Exercise1Test extends PetDomainForKata
+{
+    @Test
+    public void getFirstNamesOfAllPeople()
+    {
+        MutableList<Person> people = this.people;
+        // Replace null, with a transformation method on MutableList.
+        MutableList<String> firstNames = people.collect(Person::getFirstName);
+        MutableList<String> expectedFirstNames = Lists.mutable.with("Mary", "Bob", "Ted", "Jake", "Barry", "Terry", "Harry", "John");
+        Assert.assertEquals(expectedFirstNames, firstNames);
+    }
+
+    @Test
+    public void getNamesOfMarySmithsPets()
+    {
+        Person person = this.getPersonNamed("Mary Smith");
+        MutableList<Pet> pets = person.getPets();
+        // Replace null, with a transformation method on MutableList.
+        MutableList<String> names = pets.collect(eachPet -> eachPet.getName());
+        Assert.assertEquals("Tabby", names.makeString());
+    }
+
+    @Test
+    public void getPeopleWithCats()
+    {
+        MutableList<Person> people = this.people;
+        MutableList<Person> peopleWithCats = people.select(person -> person.hasPet(PetType.CAT));
+        Verify.assertSize(2, peopleWithCats);
+    }
+
+    @Test
+    public void getPeopleWithoutCats()
+    {
+        MutableList<Person> people = this.people;
+        MutableList<Person> peopleWithoutCats = people.reject(person -> person.hasPet(PetType.CAT));
+        Verify.assertSize(6, peopleWithoutCats);
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise2Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise2Test.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Exercise2Test extends PetDomainForKata
+{
+    @Test
+    public void doAnyPeopleHaveCats()
+    {
+        // Replace null with a predicate which checks for PetType.CAT.
+        Predicate<Person> predicate = person -> person.hasPet(PetType.CAT);
+        Assert.assertTrue(this.people.anySatisfy(predicate));
+    }
+
+    @Test
+    public void doAllPeopleHavePets()
+    {
+        Predicate<Person> predicate = person -> person.isPetPerson();
+        // Replace with something that checks if all people have pets.
+        boolean result = this.people.allSatisfy(predicate);
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void howManyPeopleHaveCats()
+    {
+        int count = this.people.count(person -> person.hasPet(PetType.CAT));
+        Assert.assertEquals(2, count);
+    }
+
+    @Test
+    public void findMarySmith()
+    {
+        Person result = this.people.detect(person -> person.named("Mary Smith"));
+        Assert.assertEquals("Mary", result.getFirstName());
+        Assert.assertEquals("Smith", result.getLastName());
+    }
+
+    @Test
+    public void getPeopleWithPets()
+    {
+        // Replace with only the pet owners.
+        MutableList<Person> petPeople = this.people.select(person -> person.isPetPerson());
+        Verify.assertSize(7, petPeople);
+    }
+
+    @Test
+    public void getAllPetsOfAllPeople()
+    {
+        Function<Person, Iterable<PetType>> function = person -> person.getPetTypes();
+        MutableSet<PetType> petTypes = this.people.flatCollect(function, Sets.mutable.empty());
+        Assert.assertEquals(
+                Sets.mutable.with(PetType.CAT, PetType.DOG, PetType.TURTLE, PetType.HAMSTER, PetType.BIRD, PetType.SNAKE),
+                petTypes);
+    }
+
+    @Test
+    public void getFirstNamesOfAllPeople()
+    {
+        MutableList<String> firstNames = this.people.collect(Person::getFirstName);
+        Assert.assertEquals(
+                Lists.mutable.with("Mary", "Bob", "Ted", "Jake", "Barry", "Terry", "Harry", "John"),
+                firstNames);
+    }
+
+    @Test
+    public void doAnyPeopleHaveCatsRefactor()
+    {
+        boolean peopleHaveCatsLambda = this.people.anySatisfy(person -> person.hasPet(PetType.CAT));
+        Assert.assertTrue(peopleHaveCatsLambda);
+
+        // Use method reference, NOT lambdas, to solve the problem below.
+        boolean peopleHaveCatsMethodRef = this.people.anySatisfyWith(Person::hasPet, PetType.CAT);
+        Assert.assertTrue(peopleHaveCatsMethodRef);
+    }
+
+    @Test
+    public void doAllPeopleHaveCatsRefactor()
+    {
+        boolean peopleHaveCatsLambda = this.people.allSatisfy(person -> person.hasPet(PetType.CAT));
+        Assert.assertFalse(peopleHaveCatsLambda);
+
+        // Use method reference, NOT lambdas, to solve the problem below.
+        boolean peopleHaveCatsMethodRef = this.people.allSatisfyWith(Person::hasPet, PetType.CAT);
+        Assert.assertFalse(peopleHaveCatsMethodRef);
+    }
+
+    @Test
+    public void getPeopleWithCatsRefator()
+    {
+        // Use method reference, NOT lambdas, to solve the problem below.
+        MutableList<Person> peopleWithCatsMethodRef = this.people.selectWith(Person::hasPet, PetType.CAT);
+        Verify.assertSize(2, peopleWithCatsMethodRef);
+    }
+
+    @Test
+    public void getPeopleWithoutCatsRefactor()
+    {
+        // Use method reference, NOT lambdas, to solve the problem below.
+        MutableList<Person> peopleWithoutCatsMethodRef = this.people.rejectWith(Person::hasPet, PetType.CAT);
+        Verify.assertSize(6, peopleWithoutCatsMethodRef);
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise3Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise3Test.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.multimap.list.MutableListMultimap;
+import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
+import org.eclipse.collections.impl.multimap.set.UnifiedSetMultimap;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Exercise3Test extends PetDomainForKata
+{
+    @Test
+    public void getCountsByPetType()
+    {
+        MutableList<PetType> petTypes = this.people.flatCollect(Person::getPets).collect(Pet::getType);
+        // Try to replace MutableMap<PetType, Integer> with a Bag<PetType>.
+        MutableBag<PetType> counts = petTypes.toBag();
+
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.CAT));
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.DOG));
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.HAMSTER));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.SNAKE));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.TURTLE));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.BIRD));
+    }
+
+    @Test
+    public void getPeopleByLastName()
+    {
+        // Try to replace MutableMap<String, MutableList<Person> with a Multimap.
+        // Hint: use the groupBy method.
+        MutableListMultimap<String, Person> lastNamesToPeople = this.people.groupBy(Person::getLastName);
+
+        Verify.assertIterableSize(3, lastNamesToPeople.get("Smith"));
+    }
+
+    @Test
+    public void getPeopleByTheirPets()
+    {
+        // Hint: Use a target collection to go from a List to MutableSetMultimap<PetType, Person>.
+        MutableSetMultimap<PetType, Person> peopleByPetType =
+                this.people.groupByEach(person -> person.getPetTypes(), UnifiedSetMultimap.newMultimap());
+
+        Verify.assertIterableSize(2, peopleByPetType.get(PetType.CAT));
+        Verify.assertIterableSize(2, peopleByPetType.get(PetType.DOG));
+        Verify.assertIterableSize(1, peopleByPetType.get(PetType.HAMSTER));
+        Verify.assertIterableSize(1, peopleByPetType.get(PetType.TURTLE));
+        Verify.assertIterableSize(1, peopleByPetType.get(PetType.BIRD));
+        Verify.assertIterableSize(1, peopleByPetType.get(PetType.SNAKE));
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import java.util.IntSummaryStatistics;
+
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.list.primitive.IntList;
+import org.eclipse.collections.api.set.primitive.IntSet;
+import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
+import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
+import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
+import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * In this set of tests, wherever you see .stream() replace it with an Eclipse Collections alternative
+ */
+public class Exercise4Test extends PetDomainForKata
+{
+    @Test
+    public void getAgeStatisticsOfPets()
+    {
+        // Try to use a MutableIntList here instead.
+        // Hints: flatMap = flatCollect, map = collect, mapToInt = collectInt
+        IntList agesLazy = this.people.asLazy()
+                .flatCollect(Person::getPets)
+                .collectInt(Pet::getAge)
+                .toList();
+        // Try to use an IntSet here instead.
+        IntSet uniqueAges = agesLazy.toSet();
+        // IntSummaryStatistics is a class in JDK 8 - Try and use it with MutableIntList.forEach().
+        IntSummaryStatistics stats = new IntSummaryStatistics();
+        agesLazy.forEach(stats::accept);
+        // Is a Set<Integer> equal to an IntSet?
+        // Hint: Try IntSets instead of Sets as the factory.
+        Assert.assertEquals(IntHashSet.newSetWith(1, 2, 3, 4), uniqueAges);
+        // Try to leverage min, max, sum, average from the Eclipse Collections Primitive API.
+        Assert.assertEquals(stats.getMin(), agesLazy.min());
+        Assert.assertEquals(stats.getMax(), agesLazy.max());
+        Assert.assertEquals(stats.getSum(), agesLazy.sum());
+        Assert.assertEquals(stats.getAverage(), agesLazy.average(), 0.0);
+        Assert.assertEquals(stats.getCount(), agesLazy.size());
+        // Hint: Match = Satisfy
+        Assert.assertTrue(agesLazy.allSatisfy(IntPredicates.greaterThan(0)));
+        Assert.assertTrue(agesLazy.allSatisfy(i -> i > 0));
+        Assert.assertFalse(agesLazy.anySatisfy(i -> i == 0));
+        Assert.assertTrue(agesLazy.noneSatisfy(i -> i < 0));
+        Assert.assertEquals(2.0d, agesLazy.median(), 0.0);
+    }
+
+    @Test
+    public void streamsToECRefactor1()
+    {
+        // Find Bob Smith.
+        Person person = this.people.detect(each -> each.named("Bob Smith"));
+
+        // Get Bob Smith's pets' names
+        String names = person.getPets().collect(Pet::getName).makeString(" & ");
+
+        Assert.assertEquals("Dolly & Spot", names);
+    }
+
+    @Test
+    public void streamsToECRefactor2()
+    {
+        // Hint: Try to replace the Map<PetType, Long> with a Bag<PetType>.
+        MutableBag<PetType> counts =
+                this.people
+                        .asUnmodifiable()
+                        .flatCollect(Person::getPets)
+                        .collect(Pet::getType)
+                        .toBag();
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.CAT));
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.DOG));
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.HAMSTER));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.SNAKE));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.TURTLE));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.BIRD));
+    }
+
+    /**
+     * The purpose of this test is to determine the top 3 pet types
+     */
+    @Test
+    public void streamsToECRefactor3()
+    {
+        // Hint: The result of groupingBy/counting can almost always be replaced by a Bag.
+        // Hint: Look for the API on Bag that might return the top 3 pet types.
+        MutableList<ObjectIntPair<PetType>> favorites =
+                this.people.asLazy()
+                        .flatCollect(Person::getPets)
+                        .collect(Pet::getType)
+                        .toBag()
+                        .topOccurrences(3);
+        Verify.assertSize(3, favorites);
+        Verify.assertContains(PrimitiveTuples.pair(PetType.CAT, 2), favorites);
+        Verify.assertContains(PrimitiveTuples.pair(PetType.DOG, 2), favorites);
+        Verify.assertContains(PrimitiveTuples.pair(PetType.HAMSTER, 2), favorites);
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise5Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise5Test.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.partition.list.PartitionMutableList;
+import org.eclipse.collections.api.set.primitive.MutableIntSet;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.primitive.IntSets;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Exercise5Test extends PetDomainForKata
+{
+    @Test
+    public void partitionPetAndNonPetPeople()
+    {
+        PartitionMutableList<Person> partitionMutableList = this.people.partition(eachPerson -> eachPerson.isPetPerson());
+        Verify.assertSize(7, partitionMutableList.getSelected());
+        Verify.assertSize(1, partitionMutableList.getRejected());
+    }
+
+    @Test
+    public void getOldestPet()
+    {
+        Pet oldestPet = this.people.flatCollect(Person::getPets).maxBy(pet -> pet.getAge());
+        Assert.assertEquals(PetType.DOG, oldestPet.getType());
+        Assert.assertEquals(4, oldestPet.getAge());
+    }
+
+    @Test
+    public void getAveragePetAge()
+    {
+        double averagePetAge = this.people.flatCollect(Person::getPets).collectDouble(Pet::getAge).average();
+        Assert.assertEquals(1.8888888888888888, averagePetAge, 0.00001);
+    }
+
+    @Test
+    public void addPetAgesToExistingSet()
+    {
+        // Hint: Use petAges as a target collection
+        MutableIntSet petAges = IntSets.mutable.with(5);
+        this.people.flatCollect(Person::getPets).collectInt(pet -> pet.getAge(), petAges);
+        Assert.assertEquals(IntSets.mutable.with(1, 2, 3, 4, 5), petAges);
+    }
+
+    @Test
+    public void refactorToEclipseCollections()
+    {
+        // Replace List and ArrayList with Eclipse Collections types.
+        MutableList<Person> people = Lists.mutable.with(
+                new Person("Mary", "Smith").addPet(PetType.CAT, "Tabby", 2),
+                new Person("Bob", "Smith")
+                        .addPet(PetType.CAT, "Dolly", 3)
+                        .addPet(PetType.DOG, "Spot", 2),
+                new Person("Ted", "Smith").addPet(PetType.DOG, "Spike", 4),
+                new Person("Jake", "Snake").addPet(PetType.SNAKE, "Serpy", 1),
+                new Person("Barry", "Bird").addPet(PetType.BIRD, "Tweety", 2),
+                new Person("Terry", "Turtle").addPet(PetType.TURTLE, "Speedy", 1),
+                new Person("Harry", "Hamster")
+                        .addPet(PetType.HAMSTER, "Fuzzy", 1)
+                        .addPet(PetType.HAMSTER, "Wuzzy", 1),
+                new Person("John", "Doe"));
+
+        // Replace Set and HashSet with Eclipse Collections types.
+        MutableIntSet petAges = people.flatCollect(Person::getPets).collectInt(Pet::getAge).toSet();
+
+        // Extra bonus - convert to a primitive collection.
+        Assert.assertEquals(IntSets.mutable.with(1, 2, 3, 4), petAges);
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/PetDomainForKata.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/PetDomainForKata.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2018 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.junit.Before;
+
+public abstract class PetDomainForKata
+{
+    protected MutableList<Person> people;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        this.people = Lists.mutable.with(
+                new Person("Mary", "Smith").addPet(PetType.CAT, "Tabby", 2),
+                new Person("Bob", "Smith")
+                        .addPet(PetType.CAT, "Dolly", 3)
+                        .addPet(PetType.DOG, "Spot", 2),
+                new Person("Ted", "Smith").addPet(PetType.DOG, "Spike", 4),
+                new Person("Jake", "Snake").addPet(PetType.SNAKE, "Serpy", 1),
+                new Person("Barry", "Bird").addPet(PetType.BIRD, "Tweety", 2),
+                new Person("Terry", "Turtle").addPet(PetType.TURTLE, "Speedy", 1),
+                new Person("Harry", "Hamster")
+                        .addPet(PetType.HAMSTER, "Fuzzy", 1)
+                        .addPet(PetType.HAMSTER, "Wuzzy", 1),
+                new Person("John", "Doe")
+        );
+    }
+
+    public Person getPersonNamed(String fullName)
+    {
+        return this.people.detectWith(Person::named, fullName);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
     <modules>
         <module>company-kata</module>
         <module>pet-kata</module>
+        <module>pet-kata-solutions</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
 The code for the Pet Kata solutions are currently located in the
pet-kata module, but on a seperate `solutions` branch, which makes it
difficult to compare against your code while working on the kata.

This change moves the Pet Kata solution code to its own module to make
it easier to compare your work against the solution.

The IntelliJ IDEA pet-kata-solutions.iml file has also been added which
is identical to the pet-kata.iml file, apart from the project id
- `<module external.linked.project.id=":pet-kata-solutions" ...>`

This commit is based on the contents of the commit 0752a26, which added
the new candy-kata module.

Signed-off-by: Barry Evans <barryevans80@gmail.com>