### PR TITLE
Add pet-kata-solutions module

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -9,6 +9,7 @@
         <module name="candy-kata" />
         <module name="company-kata" />
         <module name="pet-kata" />
+        <module name="pet-kata-solutions" />
       </profile>
     </annotationProcessing>
     <bytecodeTargetLevel>
@@ -17,7 +18,7 @@
       <module name="eclipse-collections-kata" target="1.8" />
       <module name="eclipse-collections-kata-parent" target="1.8" />
       <module name="pet-kata" target="1.8" />
+      <module name="pet-kata-solutions" target="1.8" />
     </bytecodeTargetLevel>
   </component>
 </project>
-

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -5,6 +5,7 @@
     <file url="file://$PROJECT_DIR$/candy-kata" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/company-kata" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/pet-kata" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/pet-kata-solutions" charset="UTF-8" />
     <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To get started, you can refer to slides for the [Instruction and Pet Kata](http:
 
 To learn wider range of functionalities, slides for [Company Kata](http://eclipse.github.io/eclipse-collections-kata/company-kata) are now available online as well. 
 
-Check out the [solution branch](https://github.com/eclipse/eclipse-collections-kata/tree/solutions) for your reference.
+Check out the [pet kata solutions module tests](https://github.com/eclipse/eclipse-collections-kata/tree/master/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata) for your reference.
 
 Enjoy happy learning with Eclipse Collections Kata!
 

--- a/pet-kata-solutions/pom.xml
+++ b/pet-kata-solutions/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019 Goldman Sachs.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ and Eclipse Distribution License v. 1.0 which accompany this distribution.
+  ~ The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~ and the Eclipse Distribution License is available at
+  ~ http://www.eclipse.org/org/documents/edl-v10.php.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>eclipse-collections-kata-parent</artifactId>
+        <groupId>org.eclipse.collections.kata</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>pet-kata-solutions</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-testutils</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/Person.java
+++ b/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/Person.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.bag.mutable.HashBag;
+import org.eclipse.collections.impl.block.factory.Predicates2;
+import org.eclipse.collections.impl.list.mutable.FastList;
+
+public class Person
+{
+    private final String firstName;
+    private final String lastName;
+    private final MutableList<Pet> pets = FastList.newList();
+
+    public Person(String firstName, String lastName)
+    {
+        this.firstName = firstName;
+        this.lastName = lastName;
+    }
+
+    public String getFirstName()
+    {
+        return this.firstName;
+    }
+
+    public String getLastName()
+    {
+        return this.lastName;
+    }
+
+    public boolean named(String name)
+    {
+        return name.equals(this.firstName + ' ' + this.lastName);
+    }
+
+    public boolean hasPet(PetType petType)
+    {
+        return this.pets.anySatisfyWith(Predicates2.attributeEqual(Pet::getType), petType);
+    }
+
+    public MutableList<Pet> getPets()
+    {
+        return this.pets;
+    }
+
+    public MutableBag<PetType> getPetTypes()
+    {
+        return this.pets.collect(Pet::getType, HashBag.newBag());
+    }
+
+    public Person addPet(PetType petType, String name, int age)
+    {
+        this.pets.add(new Pet(petType, name, age));
+        return this;
+    }
+
+    public boolean isPetPerson()
+    {
+        return this.getNumberOfPets() >= 1;
+    }
+
+    public int getNumberOfPets()
+    {
+        return this.pets.size();
+    }
+}

--- a/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/Pet.java
+++ b/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/Pet.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+public class Pet
+{
+    private final PetType type;
+    private final String name;
+    private final int age;
+
+    public Pet(PetType type, String name, int age)
+    {
+        this.type = type;
+        this.name = name;
+        this.age = age;
+    }
+
+    public PetType getType()
+    {
+        return this.type;
+    }
+
+    public String getName()
+    {
+        return this.name;
+    }
+
+    public int getAge()
+    {
+        return this.age;
+    }
+}

--- a/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/PetType.java
+++ b/pet-kata-solutions/src/main/java/org/eclipse/collections/petkata/PetType.java
@@ -8,4 +8,9 @@
  * http://www.eclipse.org/org/documents/edl-v10.php.
  */
 
-include 'company-kata', 'pet-kata', 'candy-kata', 'pet-kata-solutions'
+package org.eclipse.collections.petkata;
+
+public enum PetType
+{
+    CAT, DOG, HAMSTER, TURTLE, BIRD, SNAKE
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise1Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise1Test.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * In the slides leading up to this exercise you should have learned about the following APIs.
+ * <p/>
+ * {@link MutableList#collect(Function)}<br>
+ * {@link MutableList#select(Predicate)}<br>
+ *
+ * @see <a href="http://eclipse.github.io/eclipse-collections-kata/pet-kata/#/2">Exercise 1 Slides</a>
+ */
+public class Exercise1Test extends PetDomainForKata
+{
+    @Test
+    public void getFirstNamesOfAllPeople()
+    {
+        MutableList<String> firstNames = this.people.collect(Person::getFirstName);
+
+        MutableList<String> expectedFirstNames = Lists.mutable.with("Mary", "Bob", "Ted", "Jake", "Barry", "Terry", "Harry", "John");
+        Assert.assertEquals(expectedFirstNames, firstNames);
+    }
+
+    @Test
+    public void getNamesOfMarySmithsPets()
+    {
+        Person person = this.getPersonNamed("Mary Smith");
+        MutableList<Pet> pets = person.getPets();
+
+        MutableList<String> names = pets.collect(Pet::getName);
+
+        Assert.assertEquals("Tabby", names.makeString());
+    }
+
+    @Test
+    public void getPeopleWithCats()
+    {
+        MutableList<Person> peopleWithCats = this.people.select(person -> person.hasPet(PetType.CAT));
+
+        Verify.assertSize(2, peopleWithCats);
+    }
+
+    @Test
+    public void getPeopleWithoutCats()
+    {
+        MutableList<Person> peopleWithoutCats = this.people.reject(person -> person.hasPet(PetType.CAT));
+
+        Verify.assertSize(6, peopleWithoutCats);
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise2Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise2Test.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.block.predicate.Predicate;
+import org.eclipse.collections.api.block.predicate.Predicate2;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * In the slides leading up to this exercise you should have learned about the following APIs.
+ * <p/>
+ * {@link MutableList#flatCollect(Function)}<br>
+ * {@link MutableList#select(Predicate)}<br>
+ * {@link MutableList#reject(Predicate)}<br>
+ * {@link MutableList#count(Predicate)}<br>
+ * {@link MutableList#detect(Predicate)}<br>
+ * {@link MutableList#anySatisfy(Predicate)}<br>
+ * {@link MutableList#allSatisfy(Predicate)}<br>
+ * {@link MutableList#noneSatisfy(Predicate)}<br>
+ * <br>
+ * You should have also learned about the following methods as well.<br>
+ * <br>
+ * {@link MutableList#selectWith(Predicate2, Object)}<br>
+ * {@link MutableList#rejectWith(Predicate2, Object)}<br>
+ * {@link MutableList#countWith(Predicate2, Object)}<br>
+ * {@link MutableList#detectWith(Predicate2, Object)}<br>
+ * {@link MutableList#anySatisfyWith(Predicate2, Object)}<br>
+ * {@link MutableList#allSatisfyWith(Predicate2, Object)}<br>
+ * {@link MutableList#noneSatisfyWith(Predicate2, Object)}<br>
+ * <br>
+ * @see <a href="http://eclipse.github.io/eclipse-collections-kata/pet-kata/#/4">Exercise 2 Slides</a>
+ */
+public class Exercise2Test extends PetDomainForKata
+{
+    @Test
+    public void doAnyPeopleHaveCats()
+    {
+        Predicate<Person> predicate = person -> person.hasPet(PetType.CAT); //replace null with a Predicate lambda which checks for PetType.CAT
+        Assert.assertTrue(this.people.anySatisfy(predicate));
+    }
+
+    @Test
+    public void doAllPeopleHavePets()
+    {
+        Predicate<Person> predicate = person -> person.isPetPerson();
+        boolean result = this.people.allSatisfy(predicate); //replace with a method call send to this.people that checks if all people have pets
+        Assert.assertFalse(result);
+    }
+
+    @Test
+    public void howManyPeopleHaveCats()
+    {
+        int count = this.people.count(person -> person.hasPet(PetType.CAT));
+        Assert.assertEquals(2, count);
+    }
+
+    @Test
+    public void findMarySmith()
+    {
+        Person result = this.people.detectWith(Person::named,"Mary Smith");
+        Assert.assertEquals("Mary", result.getFirstName());
+        Assert.assertEquals("Smith", result.getLastName());
+    }
+
+    @Test
+    public void getPeopleWithPets()
+    {
+        MutableList<Person> petPeople = this.people.select(person -> person.isPetPerson()); // replace with only the pet owners
+        Verify.assertSize(7, petPeople);
+    }
+
+    @Test
+    public void getAllPetTypesOfAllPeople()
+    {
+        Function<Person, Iterable<PetType>> function = person -> person.getPetTypes();
+        MutableSet<PetType> petTypes = this.people.flatCollect(function, Sets.mutable.empty());
+        Assert.assertEquals(
+                Sets.mutable.with(PetType.CAT, PetType.DOG, PetType.TURTLE, PetType.HAMSTER, PetType.BIRD, PetType.SNAKE),
+                petTypes);
+    }
+
+    @Test
+    public void getFirstNamesOfAllPeople()
+    {
+        MutableList<String> firstNames = this.people.collect(Person::getFirstName);  // Transform this.people into a list of first names
+        Assert.assertEquals(
+                Lists.mutable.with("Mary", "Bob", "Ted", "Jake", "Barry", "Terry", "Harry", "John"),
+                firstNames);
+    }
+
+    @Test
+    public void doAnyPeopleHaveCatsRefactor()
+    {
+        boolean peopleHaveCatsLambda = this.people.anySatisfy(person -> person.hasPet(PetType.CAT));
+        Assert.assertTrue(peopleHaveCatsLambda);
+
+        //use method reference, NOT lambdas, to solve the problem below
+        boolean peopleHaveCatsMethodRef = this.people.anySatisfyWith(Person::hasPet,PetType.CAT);
+        Assert.assertTrue(peopleHaveCatsMethodRef);
+    }
+
+    @Test
+    public void doAllPeopleHaveCatsRefactor()
+    {
+        boolean peopleHaveCatsLambda = this.people.allSatisfy(person -> person.hasPet(PetType.CAT));
+        Assert.assertFalse(peopleHaveCatsLambda);
+
+        //use method reference, NOT lambdas, to solve the problem below
+        boolean peopleHaveCatsMethodRef = this.people.allSatisfyWith(Person::hasPet, PetType.CAT);
+        Assert.assertFalse(peopleHaveCatsMethodRef);
+    }
+
+    @Test
+    public void getPeopleWithCatsRefactor()
+    {
+        //use method reference, NOT lambdas, to solve the problem below
+        MutableList<Person> peopleWithCatsMethodRef = this.people.selectWith(Person::hasPet, PetType.CAT);
+        Verify.assertSize(2, peopleWithCatsMethodRef);
+    }
+
+    @Test
+    public void getPeopleWithoutCatsRefactor()
+    {
+        //use method reference, NOT lambdas, to solve the problem below
+        MutableList<Person> peopleWithoutCatsMethodRef = this.people.rejectWith(Person::hasPet, PetType.CAT);
+        Verify.assertSize(6, peopleWithoutCatsMethodRef);
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise3Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise3Test.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.bag.Bag;
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.block.function.Function;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.map.MutableMap;
+import org.eclipse.collections.api.multimap.Multimap;
+import org.eclipse.collections.api.multimap.list.MutableListMultimap;
+import org.eclipse.collections.api.multimap.set.MutableSetMultimap;
+import org.eclipse.collections.api.set.MutableSet;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.Maps;
+import org.eclipse.collections.impl.factory.Multimaps;
+import org.eclipse.collections.impl.factory.Sets;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * In the slides leading up to this exercise you should have learned about the following APIs.
+ * <p/>
+ * {@link Bag}<br>
+ * {@link MutableBag}<br>
+ * {@link MutableList#toBag()}<br>
+ * <br>
+ * {@link Multimap}<br>
+ * {@link MutableList#groupBy(Function)}<br>
+ * {@link MutableList#groupByEach(Function)}<br>
+ * {@link Multimaps}<br>
+ *
+ * @see <a href="http://eclipse.github.io/eclipse-collections-kata/pet-kata/#/6">Exercise 3 Slides</a>
+ */
+public class Exercise3Test extends PetDomainForKata
+{
+    @Test
+    public void getCountsByPetType()
+    {
+        MutableBag<PetType> counts =
+                this.people.flatCollect(Person::getPets).countBy(Pet::getType);
+
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.CAT));
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.DOG));
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.HAMSTER));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.SNAKE));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.TURTLE));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.BIRD));
+    }
+
+    @Test
+    public void getPeopleByLastName()
+    {
+        MutableListMultimap<String, Person> lastNamesToPeople =
+                this.people.groupBy(Person::getLastName);
+
+        Verify.assertIterableSize(3, lastNamesToPeople.get("Smith"));
+    }
+
+    @Test
+    public void getPeopleByTheirPets()
+    {
+        MutableSetMultimap<PetType, Person> multimap =
+                this.people.groupByEach(
+                        Person::getPetTypes,
+                        Multimaps.mutable.set.empty());
+
+        Verify.assertIterableSize(2, multimap.get(PetType.CAT));
+        Verify.assertIterableSize(2, multimap.get(PetType.DOG));
+        Verify.assertIterableSize(1, multimap.get(PetType.HAMSTER));
+        Verify.assertIterableSize(1, multimap.get(PetType.TURTLE));
+        Verify.assertIterableSize(1, multimap.get(PetType.BIRD));
+        Verify.assertIterableSize(1, multimap.get(PetType.SNAKE));
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.bag.MutableBag;
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.list.primitive.MutableIntList;
+import org.eclipse.collections.api.set.primitive.IntSet;
+import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
+import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
+import org.eclipse.collections.impl.factory.primitive.IntSets;
+import org.eclipse.collections.impl.test.Verify;
+import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.IntSummaryStatistics;
+
+/**
+ * In this set of tests, wherever you see .stream() replace it with an Eclipse Collections alternative.
+ */
+public class Exercise4Test extends PetDomainForKata {
+    @Test
+    public void getAgeStatisticsOfPets() {
+        // Try to use a MutableIntList here instead
+        // Hints: flatMap = flatCollect, map = collect, mapToInt = collectInt
+        MutableIntList petAges = this.people
+                .flatCollect(Person::getPets)
+                .collectInt(Pet::getAge);
+
+        // Try to use an IntSet here instead
+        IntSet uniqueAges = petAges.toSet();
+
+        // IntSummaryStatistics is a class in JDK 8 - Try and use it with MutableIntList.forEach()
+        IntSummaryStatistics stats = new IntSummaryStatistics();
+        petAges.forEach(stats::accept);
+
+        // Is a Set<Integer> equal to an IntSet?
+        // Hint: Try IntSets instead of Sets as the factory
+        Assert.assertEquals(IntSets.immutable.of(1, 2, 3, 4), uniqueAges);
+
+        // Try to leverage min, max, sum, average from the Eclipse Collections Primitive API
+        Assert.assertEquals(stats.getMin(), petAges.min());
+        Assert.assertEquals(stats.getMax(), petAges.max());
+        Assert.assertEquals(stats.getSum(), petAges.sum());
+        Assert.assertEquals(stats.getAverage(), petAges.average(), 0.0);
+        Assert.assertEquals(stats.getCount(), petAges.size());
+
+        // Hint: Match = Satisfy
+        Assert.assertTrue(petAges.allSatisfy(IntPredicates.greaterThan(0)));
+        Assert.assertTrue(petAges.allSatisfy(i -> i > 0));
+        Assert.assertFalse(petAges.anySatisfy(i -> i == 0));
+        Assert.assertTrue(petAges.noneSatisfy(i -> i < 0));
+        Assert.assertEquals(2.0d, petAges.median(), 0.0);
+    }
+
+    @Test
+    public void streamsToECRefactor1() {
+        // Find Bob Smith
+        Person person = this.people.detect(each -> each.named("Bob Smith"));
+
+        // Get Bob Smith's pets' names
+        String names = person.getPets()
+                .collect(Pet::getName)
+                .makeString(" & ");
+
+        Assert.assertEquals("Dolly & Spot", names);
+    }
+
+    @Test
+    public void streamsToECRefactor2() {
+        // Hint: Try to replace the Map<PetType, Long> with a Bag<PetType>
+        MutableBag<PetType> counts = this.people
+                .asUnmodifiable()
+                .flatCollect(Person::getPets)
+                .countBy(Pet::getType);
+
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.CAT));
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.DOG));
+        Assert.assertEquals(2, counts.occurrencesOf(PetType.HAMSTER));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.SNAKE));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.TURTLE));
+        Assert.assertEquals(1, counts.occurrencesOf(PetType.BIRD));
+    }
+
+
+    /**
+     * The purpose of this test is to determine the top 3 pet types.
+     */
+    @Test
+    public void streamsToECRefactor3() {
+        // Hint: The result of groupingBy/counting can almost always be replaced by a Bag
+        // Hint: Look for the API on Bag that might return the top 3 pet types
+        MutableList<ObjectIntPair<PetType>> favorites = this.people
+                .flatCollect(Person::getPets)
+                .countBy(Pet::getType)
+                .topOccurrences(3);
+
+        Verify.assertSize(3, favorites);
+        Verify.assertContains(PrimitiveTuples.pair(PetType.CAT, 2), favorites);
+        Verify.assertContains(PrimitiveTuples.pair(PetType.DOG, 2), favorites);
+        Verify.assertContains(PrimitiveTuples.pair(PetType.HAMSTER, 2), favorites);
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise5Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise5Test.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.partition.list.PartitionMutableList;
+import org.eclipse.collections.api.set.primitive.MutableIntSet;
+import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.primitive.IntSets;
+import org.eclipse.collections.impl.test.Verify;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class Exercise5Test extends PetDomainForKata {
+    @Test
+    public void partitionPetAndNonPetPeople() {
+        PartitionMutableList<Person> partitionMutableList = this.people
+                .partition(Person::isPetPerson);
+
+        Verify.assertSize(7, partitionMutableList.getSelected());
+        Verify.assertSize(1, partitionMutableList.getRejected());
+    }
+
+    @Test
+    public void getOldestPet() {
+        Pet oldestPet = this.people
+                .flatCollect(Person::getPets)
+                .maxBy(pet -> pet.getAge());
+
+        Assert.assertEquals(PetType.DOG, oldestPet.getType());
+        Assert.assertEquals(4, oldestPet.getAge());
+    }
+
+    @Test
+    public void getAveragePetAge() {
+        double averagePetAge = this.people
+                .flatCollect(Person::getPets)
+                .collectDouble(pet -> pet.getAge())
+                .average();
+
+        Assert.assertEquals(1.8888888888888888, averagePetAge, 0.00001);
+    }
+
+    @Test
+    public void addPetAgesToExistingSet() {
+        // Hint: Use petAges as a target collection
+        MutableIntSet petAges = IntSets.mutable.with(5);
+
+        this.people.flatCollect(Person::getPets)
+                .collectInt(pet -> pet.getAge(), petAges);
+
+        Assert.assertEquals(IntSets.mutable.with(1, 2, 3, 4, 5), petAges);
+    }
+
+    @Test
+    public void refactorToEclipseCollections() {
+        // Replace List and ArrayList with Eclipse Collections types
+        MutableList<Person> people = Lists.mutable.with(
+                new Person("Mary", "Smith").addPet(PetType.CAT, "Tabby", 2),
+                new Person("Bob", "Smith")
+                        .addPet(PetType.CAT, "Dolly", 3)
+                        .addPet(PetType.DOG, "Spot", 2),
+                new Person("Ted", "Smith").addPet(PetType.DOG, "Spike", 4),
+                new Person("Jake", "Snake").addPet(PetType.SNAKE, "Serpy", 1),
+                new Person("Barry", "Bird").addPet(PetType.BIRD, "Tweety", 2),
+                new Person("Terry", "Turtle").addPet(PetType.TURTLE, "Speedy", 1),
+                new Person("Harry", "Hamster")
+                        .addPet(PetType.HAMSTER, "Fuzzy", 1)
+                        .addPet(PetType.HAMSTER, "Wuzzy", 1),
+                new Person("John", "Doe")
+        );
+
+        // Replace Set and HashSet with Eclipse Collections types
+        MutableIntSet petAges = people
+                .flatCollect(Person::getPets)
+                .collectInt(pet -> pet.getAge())
+                .toSet();
+
+        //extra bonus - convert to a primitive collection
+        Assert.assertEquals(IntSets.mutable.with(1, 2, 3, 4), petAges);
+    }
+}

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/PetDomainForKata.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/PetDomainForKata.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2019 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.petkata;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.junit.Before;
+
+public abstract class PetDomainForKata
+{
+    protected MutableList<Person> people;
+
+    @Before
+    public void setUp() throws Exception
+    {
+        this.people = Lists.mutable.with(
+                new Person("Mary", "Smith").addPet(PetType.CAT, "Tabby", 2),
+                new Person("Bob", "Smith")
+                        .addPet(PetType.CAT, "Dolly", 3)
+                        .addPet(PetType.DOG, "Spot", 2),
+                new Person("Ted", "Smith").addPet(PetType.DOG, "Spike", 4),
+                new Person("Jake", "Snake").addPet(PetType.SNAKE, "Serpy", 1),
+                new Person("Barry", "Bird").addPet(PetType.BIRD, "Tweety", 2),
+                new Person("Terry", "Turtle").addPet(PetType.TURTLE, "Speedy", 1),
+                new Person("Harry", "Hamster")
+                        .addPet(PetType.HAMSTER, "Fuzzy", 1)
+                        .addPet(PetType.HAMSTER, "Wuzzy", 1),
+                new Person("John", "Doe")
+        );
+    }
+
+    public Person getPersonNamed(String fullName)
+    {
+        return this.people.detectWith(Person::named, fullName);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
         <module>company-kata</module>
         <module>pet-kata</module>
         <module>candy-kata</module>
+        <module>pet-kata-solutions</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
The code for the Pet Kata solutions are currently located in the
pet-kata module, but on a separate _solutions_ branch, which makes it
difficult to compare against your code while working on the kata.

This change moves the Pet Kata solution code to its own module to make
it easier to compare your work against the solution.

The code on the solutions branch is also out of date with the current
version of the pet-kata module. This change brings the solution code up
to date with the solution code in the README.md file, and rectifies
some discrepancies:
- add solution code from slides (IntPredicates & median)
- add stats slide updates
- remove asLazy from favorites ObjectIntPair

This commit is based on the contents of the commit 0752a26, which added
the new candy-kata module.

Signed-off-by: Barry Evans <barryevans80@gmail.com>