### PR TITLE
Update README to point to Kata READMEs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,11 @@ In the "Open Project" dialog you might select the option "Open Required Projects
 
 Work on Kata exercises
 ----------------------
-There are three separate katas under different directories (Pet Kata, Company Kata, and Candy Kata).
+There are three separate katas under different directories:
 
-```
-pet-kata/src/tests
-company-kata/src/tests
-candy-kata/src/tests
-```
+1. [Pet Kata](pet-kata)
+1. [Company Kata](company-kata)
+1. [Candy Kata](candy-kata)
 
 To get started, you can refer to slides for the [Instruction and Pet Kata](http://eclipse.github.io/eclipse-collections-kata/) to learn how to set-up Kata, basic features of Eclipse Collections corresponding to each Pet Kata exercise and then solutions. 
 Check out the [pet kata solutions module tests](https://github.com/eclipse/eclipse-collections-kata/tree/master/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata) for your reference.
@@ -71,7 +69,6 @@ To learn wider range of functionalities, slides for [Company Kata](http://eclips
 To learn more about the Bag data structure, take a look at the [Candy Kata](candy-kata).
 
 Enjoy happy learning with Eclipse Collections Kata!
-
 
 Reference Guide
 ---------------


### PR DESCRIPTION
Signed-off-by: Rinat Gatyatullin <rinattalgatovich.gatyatullin@bnymellon.com>

Changed the README to point to the kata directories and the READMEs @donraab just created. If you want to see what it looks and functions like, you can look at [my fork](https://github.com/rinatigati/eclipse-collections-kata).