### PR TITLE
Added a separate test for retrieving the median of pet ages.

### DIFF
--- a/docs/pet-kata/slides.md
+++ b/docs/pet-kata/slides.md
@@ -1003,6 +1003,21 @@ public void streamsToECRefactor3()
 ```
 
 
+Get median of pet ages
+----------------------
+```java
+@Test
+public void getMedianOfPetAges()
+{
+  var petAges = this.people
+    .flatCollect(Person::getPets)
+    .collectInt(Pet::getAge);
+
+   Assert.assertEquals(2.0d, petAges.median(), 0.0);
+}
+```
+
+
 
 Exercise 5
 ==========

--- a/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
+++ b/pet-kata-solutions/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
@@ -11,19 +11,13 @@
 package org.eclipse.collections.petkata;
 
 import org.eclipse.collections.api.bag.MutableBag;
-import org.eclipse.collections.api.list.MutableList;
-import org.eclipse.collections.api.list.primitive.MutableIntList;
-import org.eclipse.collections.api.set.primitive.ImmutableIntSet;
 import org.eclipse.collections.api.set.primitive.IntSet;
-import org.eclipse.collections.api.tuple.primitive.ObjectIntPair;
 import org.eclipse.collections.impl.block.factory.primitive.IntPredicates;
 import org.eclipse.collections.impl.factory.primitive.IntSets;
 import org.eclipse.collections.impl.test.Verify;
 import org.eclipse.collections.impl.tuple.primitive.PrimitiveTuples;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.util.IntSummaryStatistics;
 
 /**
  * In this set of tests, wherever you see .stream() replace it with an Eclipse Collections alternative.
@@ -53,7 +47,6 @@ public class Exercise4Test extends PetDomainForKata
         Assert.assertTrue(petAges.allSatisfy(i -> i > 0));
         Assert.assertFalse(petAges.anySatisfy(i -> i == 0));
         Assert.assertTrue(petAges.noneSatisfy(i -> i < 0));
-        Assert.assertEquals(2.0d, petAges.median(), 0.0);
     }
 
     @Test
@@ -101,5 +94,15 @@ public class Exercise4Test extends PetDomainForKata
         Verify.assertContains(PrimitiveTuples.pair(PetType.CAT, 2), favorites);
         Verify.assertContains(PrimitiveTuples.pair(PetType.DOG, 2), favorites);
         Verify.assertContains(PrimitiveTuples.pair(PetType.HAMSTER, 2), favorites);
+    }
+
+    @Test
+    public void getMedianOfPetAges()
+    {
+        var petAges = this.people
+                .flatCollect(Person::getPets)
+                .collectInt(Pet::getAge);
+
+        Assert.assertEquals(2.0d, petAges.median(), 0.0);
     }
 }

--- a/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
+++ b/pet-kata/src/test/java/org/eclipse/collections/petkata/Exercise4Test.java
@@ -21,6 +21,8 @@ import org.eclipse.collections.impl.test.Verify;
 import org.junit.Assert;
 import org.junit.Test;
 
+import static java.lang.Math.abs;
+
 /**
  * In this set of tests, wherever you see .stream() replace it with an Eclipse Collections alternative.
  * <p/>
@@ -70,7 +72,6 @@ public class Exercise4Test extends PetDomainForKata
 
         // Hint: JDK xyzMatch = Eclipse Collections xyzSatisfy
         // Use IntPredicates, lambda or both?
-        // Is it possible to add a test in order to determine the average without using stats?
         Assert.assertTrue(petAges.stream().allMatch(i -> i > 0));
         Assert.assertFalse(petAges.stream().anyMatch(i -> i == 0));
         Assert.assertTrue(petAges.stream().noneMatch(i -> i < 0));
@@ -143,5 +144,39 @@ public class Exercise4Test extends PetDomainForKata
         Verify.assertContains(new AbstractMap.SimpleEntry<>(PetType.CAT, Long.valueOf(2)), favorites);
         Verify.assertContains(new AbstractMap.SimpleEntry<>(PetType.DOG, Long.valueOf(2)), favorites);
         Verify.assertContains(new AbstractMap.SimpleEntry<>(PetType.HAMSTER, Long.valueOf(2)), favorites);
+    }
+
+    @Test
+    public void getMedianOfPetAges()
+    {
+        Assert.fail("Refactor to Eclipse Collections. Don't forget to comment this out or delete it when you are done.");
+
+        // Try to use a MutableIntList here instead
+        // Hints: flatMap = flatCollect, map = collect, mapToInt = collectInt
+        var petAges = this.people
+                .stream()
+                .map(Person::getPets)
+                .flatMap(List::stream)
+                .mapToInt(Pet::getAge)
+                .boxed()
+                .collect(Collectors.toList());
+
+        // Try to refactor the code block finding the median the JDK way
+        // Use the EC median method
+        var sortedPetAges = petAges.stream().sorted().collect(Collectors.toList());
+
+        double median;
+        if (0 == sortedPetAges.size() % 2)
+        {
+            // The median of a list of even numbers is the average of the two middle items
+            median = sortedPetAges.stream().skip((sortedPetAges.size() / 2) - 1).limit(2L).mapToInt(i -> i).average().getAsDouble();
+        }
+        else
+        {
+            // The median of a list of odd numbers is the middle item
+            median = sortedPetAges.get(abs(sortedPetAges.size() / 2)).doubleValue();
+        }
+
+        Assert.assertEquals(2.0, median, 0.0);
     }
 }


### PR DESCRIPTION
Added a test for retrieving the median of the pet ages. The solution was already in exercise 4, but it was not yet contained in the exercise itself. Created a separate test for it as suggested in https://github.com/eclipse/eclipse-collections-kata/pull/166