### PR TITLE
Company kata exercise 2 inconsistencies

### DIFF
--- a/company-kata-solutions/src/main/java/org/eclipse/collections/companykata/Company.java
+++ b/company-kata-solutions/src/main/java/org/eclipse/collections/companykata/Company.java
@@ -86,7 +86,7 @@ public class Company
      * Remove the Assert.fail() and replace the null with an appropriate implementation.
      * Use a {@link Predicate} to find a {@link Customer} with the name given.
      *
-     * @see org.eclipse.collections.api.RichIterable#flatCollect(Function)
+     * @see org.eclipse.collections.api.RichIterable#detect(Predicate)
      */
     public Customer getCustomerNamed(String name)
     {

--- a/company-kata/src/main/java/org/eclipse/collections/companykata/Company.java
+++ b/company-kata/src/main/java/org/eclipse/collections/companykata/Company.java
@@ -92,7 +92,7 @@ public class Company
      * Remove the Assert.fail() and replace the null with an appropriate implementation.
      * Use a {@link Predicate} to find a {@link Customer} with the name given.
      *
-     * @see org.eclipse.collections.api.RichIterable#flatCollect(Function)
+     * @see org.eclipse.collections.api.RichIterable#detect(Predicate)
      */
     public Customer getCustomerNamed(String name)
     {


### PR DESCRIPTION
Found two inconsistencies in the company kata exercise 2:

For exercise 2, the findMary and findPete tests can be fixed by changing the getCustomerNamed method of Company. The javadoc refers to the flatCollect method. This is confusing while the detect method should be given as a hint.

The slides show code which should prove that an ImmutableList is really immutable. But an instanceof check is made with the ImmutableTripletonList class which has package visibility. This code cannot compile, it should be checked whether it is an ImmutableList instance according to me.