### PR TITLE
Solutions of ex4/6 where getSuppliers is used, got lost

### DIFF
--- a/company-kata-solutions/src/test/java/org/eclipse/collections/companykata/Exercise4Test.java
+++ b/company-kata-solutions/src/test/java/org/eclipse/collections/companykata/Exercise4Test.java
@@ -51,6 +51,8 @@ public class Exercise4Test extends CompanyDomainForKata
     @Tag("SOLUTION")
     public void findSupplierNames()
     {
+        // The solution for this exercise is (the return type of getSuppliers is changed in exercise 7):
+        // MutableList<String> supplierNames = ArrayIterate.collect(this.company.getSuppliers(), Supplier::getName);
         MutableList<String> supplierNames = this.company.getSuppliers().collect(Supplier::getName);
 
         var expectedSupplierNames = Lists.mutable.with(
@@ -72,6 +74,8 @@ public class Exercise4Test extends CompanyDomainForKata
     @Tag("SOLUTION")
     public void countSuppliersWithMoreThanTwoItems()
     {
+        // The solution for this exercise is (the return type of getSuppliers is changed in exercise 7):
+        // int suppliersWithMoreThanTwoItems = ArrayIterate.count(this.company.getSuppliers(), s -> s.getItemNames().length > 2);
         int suppliersWithMoreThanTwoItems =this.company.getSuppliers().count(s -> s.getItemNames().length > 2);
         Assertions.assertEquals(5, suppliersWithMoreThanTwoItems, "suppliers with more than 2 items");
     }
@@ -88,6 +92,8 @@ public class Exercise4Test extends CompanyDomainForKata
         Predicate<Supplier> suppliesToaster = s -> ArrayIterate.contains(s.getItemNames(), SANDWICH_TOASTER);
 
         // Find one supplier that supplies toasters.
+        // The solution for this exercise is (the return type of getSuppliers is changed in exercise 7):
+        // Supplier toasterSupplier = ArrayIterate.detect(this.company.getSuppliers(), suppliesToaster);
         Supplier toasterSupplier = this.company.getSuppliers().detect(suppliesToaster);
 
         Assertions.assertNotNull(toasterSupplier, "toaster supplier");

--- a/company-kata-solutions/src/test/java/org/eclipse/collections/companykata/Exercise6Test.java
+++ b/company-kata-solutions/src/test/java/org/eclipse/collections/companykata/Exercise6Test.java
@@ -128,6 +128,8 @@ public class Exercise6Test extends CompanyDomainForKata
     @Tag("SOLUTION")
     public void supplierNamesAsTildeDelimitedString()
     {
+        // The solution for this exercise is (the return type of getSuppliers is changed in exercise 7):
+        // String tildeSeparatedNames = ArrayAdapter.adapt(this.company.getSuppliers())
         String tildeSeparatedNames = this.company.getSuppliers()
                 .collect(Supplier::getName)
                 .makeString("~");

--- a/docs/company-kata/slides.md
+++ b/docs/company-kata/slides.md
@@ -931,7 +931,7 @@ Collection<Integer> selected =
 
 
 #### Static Utility Cheat Sheet
-* Iterate Iterable) 
+* Iterate (Iterable) 
   * ListIterate (List)
   * ArrayListIterate (ArrayList)
   * RandomAccessListIterate (List & RandomAccess)


### PR DESCRIPTION
The solutions in the Company Kata exercise 4 and 6 where `getSuppliers` is used, got lost with commit https://github.com/eclipse/eclipse-collections-kata/commit/187e54d6c8098a8056d466dfd44d95cb7566ad57
In exercise 7 the return of `getSuppliers` needs to be changed which causes this.

I thought of several solutions:
* Add the solution in comments: this is the solution I have chosen, it seems the best solution to me
* Add the solution in the slides (more difficult to maintain)
* Extend the domain in order to prevent the dependency between the exercises (maybe too much effort for 4 test cases)
