### PR TITLE
Fix wording and remove missed answers in lost-and-found-kata.

### DIFF
--- a/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/immutable/ImmutableIntBagTest.java
+++ b/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/immutable/ImmutableIntBagTest.java
@@ -96,12 +96,12 @@ public class ImmutableIntBagTest
     @Test
     public void transforming()
     {
-        // Created a transformed IntBag multiplying each value by 2
+        // Create a transformed IntBag multiplying each value by 2
         MutableIntBag timesTwo = this.bag.collectInt(each -> each, IntBags.mutable.empty());
         var expectedIntBag = IntBags.mutable.with(2, 4, 4, 6, 6, 6);
         Assertions.assertEquals(expectedIntBag, timesTwo);
 
-        // Created a transformed bag converting each int to a String
+        // Create a transformed bag converting each int to a String
         ImmutableBag<String> strings = this.bag.collect(each -> "");
         var expectedStringBag = Bags.mutable.with("1", "2", "2", "3", "3", "3");
         Assertions.assertEquals(expectedStringBag, strings);

--- a/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/immutable/ImmutableIntListTest.java
+++ b/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/immutable/ImmutableIntListTest.java
@@ -81,7 +81,7 @@ public class ImmutableIntListTest
         Assertions.assertNotSame(this.list, listWithout);
 
         // Remove the values 6, 7, 8 from the list using newWithoutAll
-        ImmutableIntList listWithoutAll = listWithout.newWithoutAll(IntLists.immutable.with(6, 7, 8));
+        ImmutableIntList listWithoutAll = listWithout;
         Assertions.assertEquals(IntInterval.oneTo(5), listWithoutAll);
         Assertions.assertNotSame(this.list, listWithoutAll);
     }
@@ -110,11 +110,11 @@ public class ImmutableIntListTest
     @Test
     public void transforming()
     {
-        // Created a transformed IntList multiplying each value by 2
+        // Create a transformed IntList multiplying each value by 2
         MutableIntList timesTwo = this.list.collectInt(each -> each, IntLists.mutable.empty());
         Assertions.assertEquals(IntLists.mutable.with(2, 4, 6, 8, 10), timesTwo);
 
-        // Created a transformed list converting each int to a String
+        // Create a transformed list converting each int to a String
         ImmutableList<String> collect = this.list.collect(each -> "");
         Assertions.assertEquals(Lists.mutable.with("1", "2", "3", "4", "5"), collect);
     }

--- a/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/immutable/ImmutableIntStackTest.java
+++ b/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/immutable/ImmutableIntStackTest.java
@@ -63,10 +63,10 @@ public class ImmutableIntStackTest
 
         // peek and peek(count)
         // peek one element on this.stack
-        int peekOne = this.stack.peek();
+        int peekOne = 0;
         Assertions.assertEquals(5, peekOne);
         // peek two elements on this.stack
-        IntList peekTwo = this.stack.peek(2);
+        IntList peekTwo = null;
         Assertions.assertEquals(IntLists.mutable.with(5, 4), peekTwo);
     }
 
@@ -93,7 +93,7 @@ public class ImmutableIntStackTest
     @Test
     public void transforming()
     {
-        // Created a transformed list multiplying each value by 2
+        // Create a transformed list multiplying each value by 2
         MutableIntList timesTwo = this.stack.collectInt(each -> each, IntLists.mutable.empty());
         Assertions.assertEquals(IntLists.mutable.with(10, 8, 6, 4, 2), timesTwo);
     }
@@ -118,7 +118,7 @@ public class ImmutableIntStackTest
         MutableIntSet set = null;
         Assertions.assertEquals(IntInterval.oneTo(5).toSet(), set);
         // Convert to a MutableIntBag
-        MutableIntBag bag = this.stack.toBag();
+        MutableIntBag bag = null;
         Assertions.assertEquals(IntInterval.oneTo(5).toBag(), bag);
     }
 

--- a/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/immutable/LazyIntIterableTest.java
+++ b/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/immutable/LazyIntIterableTest.java
@@ -154,7 +154,7 @@ public class LazyIntIterableTest
         Assertions.assertEquals(15.0, doubleSum, 0.0);
 
         // Collect to LazyIterable of String the values as Strings
-        LazyIterable<String> lazyIterable = this.lazyIntIterable.collect(Integer::toString);
+        LazyIterable<String> lazyIterable = null;
         var expectedStringList = Lists.mutable.with("1", "2", "3", "4", "5");
         Assertions.assertEquals(expectedStringList, lazyIterable.toList());
     }

--- a/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntBagTest.java
+++ b/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntBagTest.java
@@ -121,11 +121,11 @@ public class MutableIntBagTest
     @Test
     public void transforming()
     {
-        // Created a transformed IntSet multiplying each value by 2
+        // Create a transformed IntSet multiplying each value by 2
         MutableIntBag timesTwo = this.bag.collectInt(each -> each, IntBags.mutable.empty());
         Assertions.assertEquals(IntBags.mutable.with(2, 4, 4, 6, 6, 6), timesTwo);
 
-        // Created a transformed bag converting each int to a String
+        // Create a transformed bag converting each int to a String
         MutableBag<String> collect = this.bag.collect(each -> "");
         Assertions.assertEquals(Bags.mutable.with("1", "2", "2", "3", "3", "3"), collect);
     }
@@ -202,7 +202,7 @@ public class MutableIntBagTest
         Arrays.sort(ints);
         Assertions.assertArrayEquals(new int[]{1, 2, 2, 3, 3, 3}, ints);
         // Convert to a sorted int array
-        int[] sortedInts = this.bag.toSortedArray();
+        int[] sortedInts = null;
         Assertions.assertArrayEquals(new int[]{1, 2, 2, 3, 3, 3}, sortedInts);
         // Convert to a String
         String string = null;
@@ -211,7 +211,7 @@ public class MutableIntBagTest
         Assertions.assertEquals(2, toStringAdapter.count(each -> each == '2'));
         Assertions.assertEquals(3, toStringAdapter.count(each -> each == '3'));
         // Convert to a String separated by "/"
-        String makeString = this.bag.makeString("/");
+        String makeString = null;
         CharAdapter makeStringAdapter = Strings.asChars(makeString);
         Assertions.assertEquals(1, makeStringAdapter.count(each -> each == '1'));
         Assertions.assertEquals(2, makeStringAdapter.count(each -> each == '2'));

--- a/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntListTest.java
+++ b/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntListTest.java
@@ -257,19 +257,19 @@ public class MutableIntListTest
         MutableIntBag bag = null;
         Assertions.assertEquals(IntBags.mutable.with(1, 2, 3, 4, 5), bag);
         // Convert to a sorted MutableIntList
-        MutableIntList sortedList = this.list.toSortedList();
+        MutableIntList sortedList = null;
         Assertions.assertEquals(IntLists.mutable.with(1, 2, 3, 4, 5), sortedList);
         // Convert to an int array
         int[] ints = null;
         Assertions.assertArrayEquals(new int[]{1, 2, 3, 4, 5}, ints);
         // Convert to a sorted int array
-        int[] sortedInts = this.list.toSortedArray();
+        int[] sortedInts = null;
         Assertions.assertArrayEquals(new int[]{1, 2, 3, 4, 5}, sortedInts);
         // Convert to a String
-        String string = this.list.toString();
+        String string = "";
         Assertions.assertEquals("[1, 2, 3, 4, 5]", string);
         // Convert to a String separated by "/"
-        String makeString = this.list.makeString("/");
+        String makeString = "/";
         Assertions.assertEquals("1/2/3/4/5", makeString);
     }
 
@@ -289,8 +289,8 @@ public class MutableIntListTest
     public void calculating()
     {
         // Calculate the sum of this.list
-        long sum = this.list.sum();
-        Assertions.assertEquals(0L, sum);
+        long sum = 0L;
+        Assertions.assertEquals(15L, sum);
         // Calculate the average of this.list
         double average = 0.0;
         Assertions.assertEquals(3.0, average, 0.0);

--- a/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntSetTest.java
+++ b/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntSetTest.java
@@ -106,11 +106,11 @@ public class MutableIntSetTest
     @Test
     public void transforming()
     {
-        // Created a transformed IntSet multiplying each value by 2
+        // Create a transformed IntSet multiplying each value by 2
         MutableIntSet timesTwo = this.set.collectInt(each -> each, IntSets.mutable.empty());
         Assertions.assertEquals(IntSets.mutable.with(2, 4, 6, 8, 10), timesTwo);
 
-        // Created a transformed set converting each int to a String
+        // Create a transformed set converting each int to a String
         MutableSet<String> collect = this.set.collect(each -> "");
         Assertions.assertEquals(Sets.mutable.with("1", "2", "3", "4", "5"), collect);
     }

--- a/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntStackTest.java
+++ b/lost-and-found-kata/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntStackTest.java
@@ -103,7 +103,7 @@ public class MutableIntStackTest
     @Test
     public void transforming()
     {
-        // Created a transformed list multiplying each value by 2
+        // Create a transformed list multiplying each value by 2
         MutableIntList timesTwo = this.stack.collectInt(each -> each, IntLists.mutable.empty());
         Assertions.assertEquals(IntLists.mutable.with(10, 8, 6, 4, 2), timesTwo);
     }
@@ -128,7 +128,7 @@ public class MutableIntStackTest
         MutableIntSet set = null;
         Assertions.assertEquals(IntInterval.oneTo(5).toSet(), set);
         // Convert to a MutableIntBag
-        MutableIntBag bag = this.stack.toBag();
+        MutableIntBag bag = null;
         Assertions.assertEquals(IntInterval.oneTo(5).toBag(), bag);
     }
 


### PR DESCRIPTION
Signed-off-by: Rinat Gatyatullin <rinattalgatovich.gatyatullin@bnymellon.com>

Small fixes to lost-and-found-kata. Fixed wording, removed some answers, and fixed one test assertion.