### PR TITLE
Switch to oracle-actions for JDK 17 download. Add 18 and 19 builds.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,18 +15,27 @@ jobs:
       matrix:
         # os: [macos-latest, ubuntu-latest, windows-latest]
         os: [ubuntu-latest]
-        java-version: [11, 17]
+        java-version: [11, 17, 18, 19]
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Git Checkout
         uses: actions/checkout@v2
-      - name: Set JDK ${{ matrix.java-version }}
+      - name: Set JDK ${{ matrix.java-version }} from jdk.java.net
+        uses: oracle-actions/setup-java@v1
+        with:
+          website: jdk.java.net
+          release: ${{ matrix.java-version }}
+        if: ${{ matrix.java-version != 11 }}
+      - name: Set JDK ${{ matrix.java-version }} from Zulu
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
+        if: ${{ matrix.java-version == 11 }}
+      - name: JDK Version
+        run: java --version
       - name: Enable Maven Cache
         uses: actions/cache@v1
         with:


### PR DESCRIPTION
According to this issue https://github.com/oracle-actions/setup-java/issues/14 it looks like 11 isn't available on oracle-actions so I had to improvise a little bit. 

Now EC Katas will have 11, 17, 18, and 19EA builds though.