### PR TITLE
Add support for JDK17 and JDK11 builds and add new jdk17 parent pom

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set JDK ${{ matrix.java-version }} from jdk.java.net
         uses: oracle-actions/setup-java@v1
         with:
@@ -29,7 +29,7 @@ jobs:
           release: ${{ matrix.java-version }}
         if: ${{matrix.java-version != 11 && matrix.java-version != 17}}
       - name: Set JDK ${{ matrix.java-version }} from Zulu
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
           java-version: ${{ matrix.java-version }}
@@ -37,7 +37,7 @@ jobs:
       - name: JDK Version
         run: java --version
       - name: Enable Maven Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -47,3 +47,9 @@ jobs:
         run: mvn install -Dmaven.javadoc.skip=true -B -V
         env:
           MAVEN_OPTS: "-Dmaven.repo.local=$HOME/.m2/repository -Xmx1g -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS"
+        if: ${{matrix.java-version == 11}}
+      - name: Maven
+        run: mvn install -f pom-jdk17.xml -Dmaven.javadoc.skip=true -B -V
+        env:
+          MAVEN_OPTS: "-Dmaven.repo.local=$HOME/.m2/repository -Xmx1g -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss:SSS"
+        if: ${{matrix.java-version != 11}}

--- a/pom-jdk17.xml
+++ b/pom-jdk17.xml
@@ -15,12 +15,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.eclipse.collections.kata</groupId>
-    <artifactId>eclipse-collections-kata-parent</artifactId>
+    <artifactId>eclipse-collections-kata-parent-17</artifactId>
     <version>7.1.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 
-    <name>Eclipse Collections Kata JDK11 modules</name>
+    <name>Eclipse Collections Kata JDK17 modules</name>
 
     <description>The Eclipse Collections Katas are a fun way to help you learn idiomatic Eclipse Collections usage.
         This particular kata is set up as a series of unit tests which fail. Your task is to make them pass, using
@@ -78,20 +78,9 @@
     </developers>
 
     <modules>
-        <module>company-kata</module>
-        <module>company-kata-solutions</module>
-        <module>pet-kata</module>
-        <module>pet-kata-solutions</module>
-        <module>candy-kata</module>
-        <module>candy-kata-solutions</module>
-        <module>converter-method-kata</module>
-        <module>converter-method-kata-solutions</module>
-        <module>top-methods-kata</module>
-        <module>top-methods-kata-solutions</module>
-        <module>lost-and-found-kata</module>
-        <module>lost-and-found-kata-solutions</module>
-        <module>jackson-kata</module>
-        <module>jackson-kata-solutions</module>
+        <module>record-kata</module>
+        <module>record-kata-solutions</module>
+        <module>pom.xml</module>
     </modules>
 
     <properties>
@@ -101,8 +90,8 @@
         <jol.version>0.16</jol.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
         <maven.compiler.fork>true</maven.compiler.fork>
         <maven.compiler.verbose>true</maven.compiler.verbose>
         <maven.compiler.meminitial>2048m</maven.compiler.meminitial>

--- a/record-kata-solutions/pom.xml
+++ b/record-kata-solutions/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023 Goldman Sachs.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ and Eclipse Distribution License v. 1.0 which accompany this distribution.
+  ~ The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~ and the Eclipse Distribution License is available at
+  ~ http://www.eclipse.org/org/documents/edl-v10.php.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>eclipse-collections-kata-parent-17</artifactId>
+        <groupId>org.eclipse.collections.kata</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+        <relativePath>../pom-jdk17.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>record-kata-solutions</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-testutils</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/record-kata-solutions/src/main/java/org/eclipse/collections/recordkata/OpenJDKDist.java
+++ b/record-kata-solutions/src/main/java/org/eclipse/collections/recordkata/OpenJDKDist.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.recordkata;
+
+record OpenJDKDist(String company, String buildName, String version){}

--- a/record-kata-solutions/src/test/java/org/eclipse/collections/recordkata/RecordSetup.java
+++ b/record-kata-solutions/src/test/java/org/eclipse/collections/recordkata/RecordSetup.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.recordkata;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class RecordSetup
+{
+    protected MutableList<OpenJDKDist> openJdkDistribution;
+
+    @BeforeEach
+    public void setUp()
+    {
+        this.openJdkDistribution = Lists.mutable.with(
+                new OpenJDKDist("Azul", "Zulu", "11"),
+                new OpenJDKDist("Azul", "Zulu", "17"),
+                new OpenJDKDist("Azul", "Zulu", "18"),
+                new OpenJDKDist("Oracle", "Openjdk", "18"),
+                new OpenJDKDist("Oracle", "Openjdk", "19"),
+                new OpenJDKDist("Oracle", "Openjdk", "20")
+
+        );
+    }
+}

--- a/record-kata-solutions/src/test/java/org/eclipse/collections/recordkata/RecordTest.java
+++ b/record-kata-solutions/src/test/java/org/eclipse/collections/recordkata/RecordTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.recordkata;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+public class RecordTest extends RecordSetup
+{
+    @Test
+    @Tag("SOLUTION")
+    public void getFieldNames()
+    {
+        MutableList<OpenJDKDist> jdkRecords = this.openJdkDistribution;
+        var zuluJava11BuildName = this.openJdkDistribution.get(0).buildName();
+        Assertions.assertNotNull(zuluJava11BuildName);
+        Assertions.assertEquals(3, (this.openJdkDistribution.countBy(OpenJDKDist::company).occurrencesOf("Azul")));
+        Assertions.assertIterableEquals(Lists.mutable.with("18", "19", "20"), this.openJdkDistribution.select(openJdk -> openJdk.company().equalsIgnoreCase("oracle")).collect(OpenJDKDist::version));
+    }
+}

--- a/record-kata/pom.xml
+++ b/record-kata/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2023 Goldman Sachs.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ and Eclipse Distribution License v. 1.0 which accompany this distribution.
+  ~ The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~ and the Eclipse Distribution License is available at
+  ~ http://www.eclipse.org/org/documents/edl-v10.php.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>eclipse-collections-kata-parent-17</artifactId>
+        <groupId>org.eclipse.collections.kata</groupId>
+        <version>7.1.0-SNAPSHOT</version>
+        <relativePath>../pom-jdk17.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>record-kata</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections-testutils</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/record-kata/src/main/java/org/eclipse/collections/recordkata/OpenJDKDist.java
+++ b/record-kata/src/main/java/org/eclipse/collections/recordkata/OpenJDKDist.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.recordkata;
+
+record OpenJDKDist(String company, String buildName, String version) {}

--- a/record-kata/src/test/java/org/eclipse/collections/recordkata/RecordSetup.java
+++ b/record-kata/src/test/java/org/eclipse/collections/recordkata/RecordSetup.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 Goldman Sachs.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.recordkata;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
+import org.junit.jupiter.api.BeforeEach;
+
+public abstract class RecordSetup
+{
+    protected MutableList<OpenJDKDist> openJdkDistribution;
+
+    @BeforeEach
+    public void setUp()
+    {
+        this.openJdkDistribution = Lists.mutable.with(
+                new OpenJDKDist("Azul", "Zulu", "11"),
+                new OpenJDKDist("Azul", "Zulu", "17"),
+                new OpenJDKDist("Azul", "Zulu", "18"),
+                new OpenJDKDist("Oracle", "Openjdk", "18"),
+                new OpenJDKDist("Oracle", "Openjdk", "19"),
+                new OpenJDKDist("Oracle", "Openjdk", "20")
+
+        );
+    }
+}

--- a/record-kata/src/test/java/org/eclipse/collections/recordkata/RecordTest.java
+++ b/record-kata/src/test/java/org/eclipse/collections/recordkata/RecordTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022 Goldman Sachs and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Eclipse Distribution License v. 1.0 which accompany this distribution.
+ * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+ * and the Eclipse Distribution License is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ */
+
+package org.eclipse.collections.recordkata;
+
+import org.eclipse.collections.api.list.MutableList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+public class RecordTest extends RecordSetup
+{
+    @Test
+    @Tag("KATA")
+    public void getFieldNames()
+    {
+        MutableList<OpenJDKDist> jdkRecords = this.openJdkDistribution;
+
+        var zuluJava11BuildName = this.openJdkDistribution.getFirstOptional().get().buildName();
+
+        Assertions.assertNotNull(zuluJava11BuildName);
+    }
+}


### PR DESCRIPTION
Add support for JDK17 and JDK11 modules to be built separately
Add new jdk17 parent pom to separate 17 builds
Easy to clean up later when upgraded to 17
Upgrade workflow versions to use the new node16 runners
Add workflow changes for 17 modules cascade call 11 modules
Add mock 17 feature record class and unit tests to test 17 builds
Test workflows in fork