### PR TITLE
Enhanced Record Kata with documentation and formatting

### DIFF
--- a/record-kata-solutions/src/main/java/org/eclipse/collections/recordkata/OpenJDKDist.java
+++ b/record-kata-solutions/src/main/java/org/eclipse/collections/recordkata/OpenJDKDist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Goldman Sachs.
+ * Copyright (c) 2023 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.

--- a/record-kata-solutions/src/test/java/org/eclipse/collections/recordkata/RecordSetup.java
+++ b/record-kata-solutions/src/test/java/org/eclipse/collections/recordkata/RecordSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Goldman Sachs.
+ * Copyright (c) 2023 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -23,12 +23,14 @@ public abstract class RecordSetup
     {
         this.openJdkDistribution = Lists.mutable.with(
                 new OpenJDKDist("Azul", "Zulu", "11"),
-                new OpenJDKDist("Azul", "Zulu", "17"),
+                new OpenJDKDist("azul", "Zulu", "17"),
                 new OpenJDKDist("Azul", "Zulu", "18"),
                 new OpenJDKDist("Oracle", "Openjdk", "18"),
                 new OpenJDKDist("Oracle", "Openjdk", "19"),
                 new OpenJDKDist("Oracle", "Openjdk", "20")
-
         );
+
+        OpenJDKDist jdk21 = new OpenJDKDist("Red Hat", "Openjdk", "21");
+        this.openJdkDistribution.add(jdk21);
     }
 }

--- a/record-kata-solutions/src/test/java/org/eclipse/collections/recordkata/RecordTest.java
+++ b/record-kata-solutions/src/test/java/org/eclipse/collections/recordkata/RecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Goldman Sachs and others.
+ * Copyright (c) 2023 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -10,8 +10,13 @@
 
 package org.eclipse.collections.recordkata;
 
+import org.eclipse.collections.api.list.ImmutableList;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.multimap.list.ImmutableListMultimap;
+import org.eclipse.collections.api.multimap.list.MutableListMultimap;
+import org.eclipse.collections.api.partition.list.PartitionImmutableList;
 import org.eclipse.collections.impl.factory.Lists;
+import org.eclipse.collections.impl.factory.Multimaps;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -20,12 +25,40 @@ public class RecordTest extends RecordSetup
 {
     @Test
     @Tag("SOLUTION")
+    public void addRedHatOpenjdk21()
+    {
+        OpenJDKDist jdk21 = new OpenJDKDist("Red Hat", "Openjdk", "21");
+        Assertions.assertEquals(jdk21, this.openJdkDistribution.getLastOptional().get());
+        Assertions.assertNotEquals(
+                new OpenJDKDist("Red Hat", "Openjdk", "20"), jdk21);
+    }
+
+    @Test
+    @Tag("SOLUTION")
     public void getFieldNames()
     {
-        MutableList<OpenJDKDist> jdkRecords = this.openJdkDistribution;
-        var zuluJava11BuildName = this.openJdkDistribution.get(0).buildName();
-        Assertions.assertNotNull(zuluJava11BuildName);
-        Assertions.assertEquals(3, (this.openJdkDistribution.countBy(OpenJDKDist::company).occurrencesOf("Azul")));
-        Assertions.assertIterableEquals(Lists.mutable.with("18", "19", "20"), this.openJdkDistribution.select(openJdk -> openJdk.company().equalsIgnoreCase("oracle")).collect(OpenJDKDist::version));
+        OpenJDKDist zuluJava11 = this.openJdkDistribution.get(0);
+        Assertions.assertEquals("Azul", zuluJava11.company());
+        Assertions.assertEquals("Zulu", zuluJava11.buildName());
+        Assertions.assertEquals("11", zuluJava11.version());
+    }
+
+    @Test
+    @Tag("SOLUTION")
+    public void countOpenJDKDistForOracle()
+    {
+        int count = this.openJdkDistribution.countBy(OpenJDKDist::company).occurrencesOf("Oracle");
+        Assertions.assertEquals(3, count);
+    }
+
+    @Test
+    @Tag("SOLUTION")
+    public void selectAllAzulZuluVersions()
+    {
+        MutableList<String> azulVersions =
+                this.openJdkDistribution.select(
+                        openJdk -> "azul".equalsIgnoreCase(openJdk.company())
+                ).collect(OpenJDKDist::version);
+        Assertions.assertIterableEquals(Lists.mutable.with("11", "17", "18"), azulVersions);
     }
 }

--- a/record-kata/README.md
+++ b/record-kata/README.md
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (c) 2023 The Bank of New York Mellon.
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v1.0
+  ~ and Eclipse Distribution License v. 1.0 which accompany this distribution.
+  ~ The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
+  ~ and the Eclipse Distribution License is available at
+  ~ http://www.eclipse.org/org/documents/edl-v10.php.
+  -->
+# **What is the Records Kata?**
+The Records Kata is a beginner Code Kata with a set exercises that a developer can complete to familiarize themselves with the records feature released in Java 16. 
+
+To read more about the motivation behind the development of the record type in Java: [JEP 395: Records](https://openjdk.org/jeps/395)
+
+
+# Getting Started
+
+Navigate through the comments in the test file:
+
+* [Record Test](./src/test/java/org/eclipse/collections/recordkata/RecordTest.java)

--- a/record-kata/src/main/java/org/eclipse/collections/recordkata/OpenJDKDist.java
+++ b/record-kata/src/main/java/org/eclipse/collections/recordkata/OpenJDKDist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Goldman Sachs.
+ * Copyright (c) 2023 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.

--- a/record-kata/src/test/java/org/eclipse/collections/recordkata/RecordSetup.java
+++ b/record-kata/src/test/java/org/eclipse/collections/recordkata/RecordSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023 Goldman Sachs.
+ * Copyright (c) 2023 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -18,6 +18,12 @@ public abstract class RecordSetup
 {
     protected MutableList<OpenJDKDist> openJdkDistribution;
 
+    /**
+     *  This method creates a list of Open JDK Distribution records defined in
+     *  {@link OpenJDKDist}
+     *
+     *  TODO: Create a new OpenJDKDist record for Red Hat Openjdk version 21 and append it to the end of the list.
+     */
     @BeforeEach
     public void setUp()
     {
@@ -28,7 +34,6 @@ public abstract class RecordSetup
                 new OpenJDKDist("Oracle", "Openjdk", "18"),
                 new OpenJDKDist("Oracle", "Openjdk", "19"),
                 new OpenJDKDist("Oracle", "Openjdk", "20")
-
         );
     }
 }

--- a/record-kata/src/test/java/org/eclipse/collections/recordkata/RecordTest.java
+++ b/record-kata/src/test/java/org/eclipse/collections/recordkata/RecordTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022 Goldman Sachs and others.
+ * Copyright (c) 2023 Goldman Sachs and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompany this distribution.
@@ -11,20 +11,75 @@
 package org.eclipse.collections.recordkata;
 
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.impl.factory.Lists;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 public class RecordTest extends RecordSetup
 {
+    /**
+     *  This is the starting point of the Record Kata. We have created a record type called OpenJDKDist
+     *  {@link OpenJDKDist}. Since our type is reused throughout our code and immutable, creating a record
+     *  for this case reduces boilerplate code and saves time. Explore how this record was declared and
+     *  complete the exercises below.
+     * <p>
+     *  There is an inherited setup method {@link RecordSetup}. The first step in this kata is to navigate
+     *  there to create an instance of our record. Afterwards, make each of the failing tests pass using
+     *  features of records and Eclipse Collections libraries.
+     *
+     */
+    @Test
+    @Tag("KATA")
+    public void addRedHatOpenjdk21()
+    {
+        OpenJDKDist jdk21 = new OpenJDKDist("Red Hat", "Openjdk", "21");
+
+        // Notice how we can just call assertEquals (which calls the .equals method) without
+        // implementing an equals method for the OpenJDKDist record. The record
+        // automatically creates an equals method that compares each field.
+        Assertions.assertEquals(jdk21, this.openJdkDistribution.getLastOptional().get());
+        Assertions.assertNotEquals(
+                new OpenJDKDist("Red Hat", "Openjdk", "20"), jdk21);
+    }
+
+    /**
+     * Now we know how to create a record. Lets use it!
+     * <p>
+     * TODO: Get the Azul Zulu version 11 Distribution from our list and extract each field.
+     */
     @Test
     @Tag("KATA")
     public void getFieldNames()
     {
-        MutableList<OpenJDKDist> jdkRecords = this.openJdkDistribution;
+        OpenJDKDist zuluJava11 = null;
+        Assertions.assertEquals("Azul", null);
+        Assertions.assertEquals("Zulu", null);
+        Assertions.assertEquals("11", null);
+    }
 
-        var zuluJava11BuildName = this.openJdkDistribution.getFirstOptional().get().buildName();
+    /**
+     * We know how to use records. Combine them with EC methods for some expressive features while
+     * simultaneously letting the code be concise. The next two methods will test this.
+     * <p>
+     * TODO: Get the number of JDK distributions that have Oracle as its company.
+     */
+    @Test
+    @Tag("KATA")
+    public void countOpenJDKDistForOracle()
+    {
+        int count = -1;
+        Assertions.assertEquals(3, count);
+    }
 
-        Assertions.assertNotNull(zuluJava11BuildName);
+    /**
+     * TODO: Get the versions of Azul Zulu JDK versions.
+     */
+    @Test
+    @Tag("KATA")
+    public void selectAllAzulZuluVersions()
+    {
+        MutableList<String> azulVersions = null;
+        Assertions.assertIterableEquals(Lists.mutable.with("11", "17", "18"), azulVersions);
     }
 }


### PR DESCRIPTION
The Record Kata is missing documentation and comments describing the intended purpose of this kata and guiding the kata taker through the exercise. 

- Added README.md to give background information on the motivation of the Kata.
- Added comments and TODOS to guide takers through the exercises
- Organized the exercises for clarity
- Added additional exercises