### PR TITLE
FIX: replace assert with assertions; MutableIntBagTest

### DIFF
--- a/lost-and-found-kata-solutions/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntBagTest.java
+++ b/lost-and-found-kata-solutions/src/test/java/org/eclipse/collections/lostandfoundkata/primitive/mutable/MutableIntBagTest.java
@@ -304,9 +304,9 @@ public class MutableIntBagTest
     @Tag("SOLUTION")
     public void occurrencesOf()
     {
-        Assert.assertEquals(1, this.bag.occurrencesOf(1));
-        Assert.assertEquals(2, this.bag.occurrencesOf(2));
-        Assert.assertEquals(3, this.bag.occurrencesOf(3));
+        Assertions.assertEquals(1, this.bag.occurrencesOf(1));
+        Assertions.assertEquals(2, this.bag.occurrencesOf(2));
+        Assertions.assertEquals(3, this.bag.occurrencesOf(3));
     }
 
     public void topOccurrences()


### PR DESCRIPTION
Replace `Assert` with `Assertions` in `MutableIntBagTest`.  [Issue Link](https://github.com/eclipse/eclipse-collections-kata/issues/361)